### PR TITLE
fix: add engines field

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
   "keywords": [
     "netlify"
   ],
+  "engines": {
+    "node": ">=8.17.0"
+  },
   "author": "Netlify",
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
Fixes https://github.com/netlify/netlify-redirect-parser/issues/22

The version matches the one in our CLI.

I postfixed the commit message type with a `!` to denote a breaking change