### PR TITLE
feat!: enforce `proxy` to be a boolean

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -77,7 +77,7 @@ const exp = {
     return redirect.path.match(/^\/\.netlify/)
   },
   isProxy(redirect) {
-    return redirect.proxy || (redirect.to.match(/^https?:\/\//) && redirect.status === 200)
+    return Boolean(redirect.proxy || (/^https?:\/\//.test(redirect.to) && redirect.status === 200))
   },
   parseFullOrigin(origin) {
     let url = null

--- a/src/line-parser.js
+++ b/src/line-parser.js
@@ -111,11 +111,8 @@ async function parse(filePath) {
       return
     }
 
-    if (common.isProxy(redirect)) {
-      redirect.proxy = true
-    }
-
-    result.addSuccess(redirect)
+    const proxy = common.isProxy(redirect)
+    result.addSuccess({ ...redirect, proxy })
   })
 
   return result

--- a/src/line-parser.test.js
+++ b/src/line-parser.test.js
@@ -9,33 +9,34 @@ const testFilesDir = path.resolve('__dirname', '../', 'test-files')
 test('simple redirects', async (t) => {
   const result = await parser.parse(path.resolve(testFilesDir, 'simple_redirects'))
   t.deepEqual(result.success, [
-    { path: '/home', to: '/' },
-    { path: '/blog/my-post.php', to: '/blog/my-post' },
-    { path: '/blog/my-post-ads.php', to: '/blog/my-post#ads' },
-    { path: '/news', to: '/blog' },
+    { path: '/home', to: '/', proxy: false },
+    { path: '/blog/my-post.php', to: '/blog/my-post', proxy: false },
+    { path: '/blog/my-post-ads.php', to: '/blog/my-post#ads', proxy: false },
+    { path: '/news', to: '/blog', proxy: false },
   ])
 })
 
 test('redirects with status codes', async (t) => {
   const result = await parser.parse(path.resolve(testFilesDir, 'status_code_redirects'))
   t.deepEqual(result.success, [
-    { path: '/home', to: '/', status: 301 },
-    { path: '/my-redirect', to: '/', status: 302 },
-    { path: '/pass-through', to: '/', status: 200 },
-    { path: '/ecommerce', to: '/store-closed', status: 404 },
+    { path: '/home', to: '/', status: 301, proxy: false },
+    { path: '/my-redirect', to: '/', status: 302, proxy: false },
+    { path: '/pass-through', to: '/', status: 200, proxy: false },
+    { path: '/ecommerce', to: '/store-closed', status: 404, proxy: false },
   ])
 })
 
 test('redirects with parameter matches', async (t) => {
   const result = await parser.parse(path.resolve(testFilesDir, 'parameter_match_redirects'))
   t.deepEqual(result.success, [
-    { path: '/', to: '/news', params: { page: 'news' } },
-    { path: '/blog', to: '/blog/:post_id', params: { post: ':post_id' } },
+    { path: '/', to: '/news', params: { page: 'news' }, proxy: false },
+    { path: '/blog', to: '/blog/:post_id', params: { post: ':post_id' }, proxy: false },
     {
       path: '/',
       to: '/about',
       params: { _escaped_fragment_: '/about' },
       status: 301,
+      proxy: false,
     },
   ])
 })
@@ -48,6 +49,7 @@ test('redirects with full hostname', async (t) => {
       scheme: 'http',
       path: '/*',
       to: 'http://www.hello.com/:splat',
+      proxy: false,
     },
   ])
 })
@@ -71,6 +73,7 @@ test('redirect with country conditions', async (t) => {
       path: '/',
       to: '/china',
       status: 302,
+      proxy: false,
       conditions: { Country: 'ch,tw' },
     },
   ])
@@ -83,6 +86,7 @@ test('redirect with country and language conditions', async (t) => {
       path: '/',
       to: '/china',
       status: 302,
+      proxy: false,
       conditions: { Country: 'il', Language: 'en' },
     },
   ])
@@ -90,7 +94,7 @@ test('redirect with country and language conditions', async (t) => {
 
 test('splat based redirect with no force instruction', async (t) => {
   const result = await parser.parse(path.resolve(testFilesDir, 'splat_no_force_redirects'))
-  t.deepEqual(result.success, [{ path: '/*', to: 'https://www.bitballoon.com/:splat', status: 301 }])
+  t.deepEqual(result.success, [{ path: '/*', to: 'https://www.bitballoon.com/:splat', status: 301, proxy: false }])
 })
 
 test('splat based redirect with force instruction', async (t) => {
@@ -100,6 +104,7 @@ test('splat based redirect with force instruction', async (t) => {
       path: '/*',
       to: 'https://www.bitballoon.com/:splat',
       status: 301,
+      proxy: false,
       force: true,
     },
   ])
@@ -112,6 +117,7 @@ test('redirect rule with equal', async (t) => {
       path: '/test',
       to: 'https://www.bitballoon.com/test=hello',
       status: 301,
+      proxy: false,
     },
   ])
 })
@@ -124,6 +130,7 @@ test('some real world edge case rules', async (t) => {
       to: '/donate/usa?source=:source&email=:email',
       params: { source: ':source', email: ':email' },
       status: 302,
+      proxy: false,
       conditions: { Country: 'us' },
     },
     {
@@ -132,7 +139,7 @@ test('some real world edge case rules', async (t) => {
       status: 200,
       proxy: true,
     },
-    { path: '/:lang/locations/*', to: '/locations/:splat', status: 200 },
+    { path: '/:lang/locations/*', to: '/locations/:splat', status: 200, proxy: false },
   ])
 })
 
@@ -176,9 +183,9 @@ test('redirect with proxy signing', async (t) => {
     path: '/api/*',
     to: 'https://api.example.com/:splat',
     status: 200,
+    proxy: true,
     force: true,
     signed: 'API_SECRET',
-    proxy: true,
   })
 })
 
@@ -190,6 +197,7 @@ test('absolute redirects with country condition', async (t) => {
     path: '/*',
     to: 'https://www.ximble.com/au/:splat',
     status: 301,
+    proxy: false,
     force: true,
     conditions: { Country: 'au' },
   })
@@ -202,6 +210,7 @@ test('redirect role conditions', async (t) => {
       path: '/admin/*',
       to: '/admin/:splat',
       status: 200,
+      proxy: false,
       conditions: { Role: 'admin' },
     },
   ])
@@ -214,6 +223,7 @@ test('redirect with multiple roles', async (t) => {
       path: '/member/*',
       to: '/member/:splat',
       status: 200,
+      proxy: false,
       conditions: { Role: 'admin,member' },
     },
   ])
@@ -222,8 +232,8 @@ test('redirect with multiple roles', async (t) => {
 test('parse forward rule', async (t) => {
   const result = await parser.parse(path.resolve(testFilesDir, 'path_forward_redirects'))
   t.deepEqual(result.success, [
-    { path: '/admin/*', to: '/admin/:splat', status: 200 },
-    { path: '/admin/*', to: '/admin/:splat', status: 200, force: true },
+    { path: '/admin/*', to: '/admin/:splat', status: 200, proxy: false },
+    { path: '/admin/*', to: '/admin/:splat', status: 200, proxy: false, force: true },
   ])
 })
 


### PR DESCRIPTION
This enforces for `proxy` to be a boolean. At the moment, it can be `true`, `null` or `undefined`.