### PR TITLE
chore: use `is-plain-obj`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "license": "MIT",
       "dependencies": {
         "@netlify/config": "^6.7.1",
-        "lodash.isplainobject": "^4.0.6"
+        "is-plain-obj": "^2.1.0"
       },
       "devDependencies": {
         "@netlify/eslint-config-node": "^3.0.4",
@@ -6508,11 +6508,6 @@
       "resolved": "https://registry.npmjs.org/lodash.islength/-/lodash.islength-4.0.1.tgz",
       "integrity": "sha1-Tpho1FJXXXUK/9NYyXlUPcIO1Xc=",
       "dev": true
-    },
-    "node_modules/lodash.isplainobject": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -15293,11 +15288,6 @@
       "resolved": "https://registry.npmjs.org/lodash.islength/-/lodash.islength-4.0.1.tgz",
       "integrity": "sha1-Tpho1FJXXXUK/9NYyXlUPcIO1Xc=",
       "dev": true
-    },
-    "lodash.isplainobject": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
     },
     "lodash.merge": {
       "version": "4.6.2",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "license": "MIT",
   "dependencies": {
     "@netlify/config": "^6.7.1",
-    "lodash.isplainobject": "^4.0.6"
+    "is-plain-obj": "^2.1.0"
   },
   "devDependencies": {
     "@netlify/eslint-config-node": "^3.0.4",

--- a/src/common.js
+++ b/src/common.js
@@ -1,4 +1,4 @@
-const isPlainObj = require('lodash.isplainobject')
+const isPlainObj = require('is-plain-obj')
 
 let URLclass = null
 
@@ -97,7 +97,6 @@ function parseFullOrigin(origin) {
 
 module.exports = {
   splatForwardRule,
-  isPlainObj,
   redirectMatch,
   addSuccess,
   addError,

--- a/src/netlify-config-parser.js
+++ b/src/netlify-config-parser.js
@@ -1,6 +1,7 @@
 const resolveConfig = require('@netlify/config')
+const isPlainObj = require('is-plain-obj')
 
-const { isPlainObj, redirectMatch, isInvalidSource, isProxy, addError, addSuccess } = require('./common')
+const { redirectMatch, isInvalidSource, isProxy, addError, addSuccess } = require('./common')
 
 function parseRedirect(result, obj, idx) {
   if (!isPlainObj(obj)) {


### PR DESCRIPTION
This switches from `lodash` to `is-plain-obj` so we get the TypeScript types.