### PR TITLE
chore!: default `params` to an empty object

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -38,6 +38,10 @@ function parseFrom(from) {
   }
 }
 
+function isSplatRule(path, status) {
+  return path.endsWith('/*') && status >= 200 && status < 300
+}
+
 function isDefined(key, value) {
   return value !== undefined
 }
@@ -52,6 +56,7 @@ module.exports = {
   isInvalidSource,
   isProxy,
   FULL_URL_MATCHER,
+  isSplatRule,
   parseFrom,
   removeUndefinedValues,
 }

--- a/src/line-parser.test.js
+++ b/src/line-parser.test.js
@@ -9,20 +9,20 @@ const testFilesDir = path.resolve('__dirname', '../', 'test-files')
 test('simple redirects', async (t) => {
   const result = await parser.parse(path.resolve(testFilesDir, 'simple_redirects'))
   t.deepEqual(result.success, [
-    { path: '/home', to: '/', proxy: false, force: false, conditions: {} },
-    { path: '/blog/my-post.php', to: '/blog/my-post', proxy: false, force: false, conditions: {} },
-    { path: '/blog/my-post-ads.php', to: '/blog/my-post#ads', proxy: false, force: false, conditions: {} },
-    { path: '/news', to: '/blog', proxy: false, force: false, conditions: {} },
+    { path: '/home', to: '/', proxy: false, force: false, params: {}, conditions: {} },
+    { path: '/blog/my-post.php', to: '/blog/my-post', proxy: false, force: false, params: {}, conditions: {} },
+    { path: '/blog/my-post-ads.php', to: '/blog/my-post#ads', proxy: false, force: false, params: {}, conditions: {} },
+    { path: '/news', to: '/blog', proxy: false, force: false, params: {}, conditions: {} },
   ])
 })
 
 test('redirects with status codes', async (t) => {
   const result = await parser.parse(path.resolve(testFilesDir, 'status_code_redirects'))
   t.deepEqual(result.success, [
-    { path: '/home', to: '/', status: 301, proxy: false, force: false, conditions: {} },
-    { path: '/my-redirect', to: '/', status: 302, proxy: false, force: false, conditions: {} },
-    { path: '/pass-through', to: '/', status: 200, proxy: false, force: false, conditions: {} },
-    { path: '/ecommerce', to: '/store-closed', status: 404, proxy: false, force: false, conditions: {} },
+    { path: '/home', to: '/', status: 301, proxy: false, force: false, params: {}, conditions: {} },
+    { path: '/my-redirect', to: '/', status: 302, proxy: false, force: false, params: {}, conditions: {} },
+    { path: '/pass-through', to: '/', status: 200, proxy: false, force: false, params: {}, conditions: {} },
+    { path: '/ecommerce', to: '/store-closed', status: 404, proxy: false, force: false, params: {}, conditions: {} },
   ])
 })
 
@@ -30,14 +30,21 @@ test('redirects with parameter matches', async (t) => {
   const result = await parser.parse(path.resolve(testFilesDir, 'parameter_match_redirects'))
   t.deepEqual(result.success, [
     { path: '/', to: '/news', params: { page: 'news' }, proxy: false, force: false, conditions: {} },
-    { path: '/blog', to: '/blog/:post_id', params: { post: ':post_id' }, proxy: false, force: false, conditions: {} },
+    {
+      path: '/blog',
+      to: '/blog/:post_id',
+      proxy: false,
+      force: false,
+      params: { post: ':post_id' },
+      conditions: {},
+    },
     {
       path: '/',
       to: '/about',
-      params: { _escaped_fragment_: '/about' },
       status: 301,
       proxy: false,
       force: false,
+      params: { _escaped_fragment_: '/about' },
       conditions: {},
     },
   ])
@@ -53,6 +60,7 @@ test('redirects with full hostname', async (t) => {
       to: 'http://www.hello.com/:splat',
       proxy: false,
       force: false,
+      params: {},
       conditions: {},
     },
   ])
@@ -67,6 +75,7 @@ test('proxy instruction', async (t) => {
       status: 200,
       proxy: true,
       force: false,
+      params: {},
       conditions: {},
     },
   ])
@@ -81,6 +90,7 @@ test('redirect with country conditions', async (t) => {
       status: 302,
       proxy: false,
       force: false,
+      params: {},
       conditions: { Country: 'ch,tw' },
     },
   ])
@@ -95,6 +105,7 @@ test('redirect with country and language conditions', async (t) => {
       status: 302,
       proxy: false,
       force: false,
+      params: {},
       conditions: { Country: 'il', Language: 'en' },
     },
   ])
@@ -103,7 +114,15 @@ test('redirect with country and language conditions', async (t) => {
 test('splat based redirect with no force instruction', async (t) => {
   const result = await parser.parse(path.resolve(testFilesDir, 'splat_no_force_redirects'))
   t.deepEqual(result.success, [
-    { path: '/*', to: 'https://www.bitballoon.com/:splat', status: 301, proxy: false, force: false, conditions: {} },
+    {
+      path: '/*',
+      to: 'https://www.bitballoon.com/:splat',
+      status: 301,
+      proxy: false,
+      force: false,
+      params: {},
+      conditions: {},
+    },
   ])
 })
 
@@ -116,6 +135,7 @@ test('splat based redirect with force instruction', async (t) => {
       status: 301,
       proxy: false,
       force: true,
+      params: {},
       conditions: {},
     },
   ])
@@ -130,6 +150,7 @@ test('redirect rule with equal', async (t) => {
       status: 301,
       proxy: false,
       force: false,
+      params: {},
       conditions: {},
     },
   ])
@@ -141,10 +162,10 @@ test('some real world edge case rules', async (t) => {
     {
       path: '/donate',
       to: '/donate/usa?source=:source&email=:email',
-      params: { source: ':source', email: ':email' },
       status: 302,
       proxy: false,
       force: false,
+      params: { source: ':source', email: ':email' },
       conditions: { Country: 'us' },
     },
     {
@@ -153,9 +174,18 @@ test('some real world edge case rules', async (t) => {
       status: 200,
       proxy: true,
       force: false,
+      params: {},
       conditions: {},
     },
-    { path: '/:lang/locations/*', to: '/locations/:splat', status: 200, proxy: false, force: false, conditions: {} },
+    {
+      path: '/:lang/locations/*',
+      to: '/locations/:splat',
+      status: 200,
+      proxy: false,
+      force: false,
+      params: {},
+      conditions: {},
+    },
   ])
 })
 
@@ -202,6 +232,7 @@ test('redirect with proxy signing', async (t) => {
     proxy: true,
     force: true,
     signed: 'API_SECRET',
+    params: {},
     conditions: {},
   })
 })
@@ -216,6 +247,7 @@ test('absolute redirects with country condition', async (t) => {
     status: 301,
     proxy: false,
     force: true,
+    params: {},
     conditions: { Country: 'au' },
   })
 })
@@ -229,6 +261,7 @@ test('redirect role conditions', async (t) => {
       status: 200,
       proxy: false,
       force: false,
+      params: {},
       conditions: { Role: 'admin' },
     },
   ])
@@ -243,6 +276,7 @@ test('redirect with multiple roles', async (t) => {
       status: 200,
       proxy: false,
       force: false,
+      params: {},
       conditions: { Role: 'admin,member' },
     },
   ])
@@ -251,8 +285,8 @@ test('redirect with multiple roles', async (t) => {
 test('parse forward rule', async (t) => {
   const result = await parser.parse(path.resolve(testFilesDir, 'path_forward_redirects'))
   t.deepEqual(result.success, [
-    { path: '/admin/*', to: '/admin/:splat', status: 200, proxy: false, force: false, conditions: {} },
-    { path: '/admin/*', to: '/admin/:splat', status: 200, proxy: false, force: true, conditions: {} },
+    { path: '/admin/*', to: '/admin/:splat', status: 200, proxy: false, force: false, params: {}, conditions: {} },
+    { path: '/admin/*', to: '/admin/:splat', status: 200, proxy: false, force: true, params: {}, conditions: {} },
   ])
 })
 

--- a/src/netlify-config-parser.js
+++ b/src/netlify-config-parser.js
@@ -1,10 +1,18 @@
 const resolveConfig = require('@netlify/config')
 const isPlainObj = require('is-plain-obj')
 
-const { addSuccess, addError, isInvalidSource, isProxy, parseFrom, removeUndefinedValues } = require('./common')
+const {
+  addSuccess,
+  addError,
+  isInvalidSource,
+  isProxy,
+  parseFrom,
+  isSplatRule,
+  removeUndefinedValues,
+} = require('./common')
 
 function splatForwardRule(path, status, force, to) {
-  return path.endsWith('/*') && to === undefined && status >= 200 && status < 300 && force
+  return to === undefined && force && isSplatRule(path, status)
 }
 
 function redirectMatch({
@@ -16,7 +24,7 @@ function redirectMatch({
   from = origin,
   destination,
   to = destination,
-  parameters,
+  parameters = {},
   params = parameters,
   query = params,
   signed,

--- a/src/netlify-config-parser.test.js
+++ b/src/netlify-config-parser.test.js
@@ -30,6 +30,7 @@ test('netlify.toml redirects parsing', async (t) => {
       status: 200,
       proxy: true,
       force: true,
+      params: {},
       conditions: {},
       signed: 'API_SIGNATURE_TOKEN',
       headers: {


### PR DESCRIPTION
This defaults `params` to an empty object and refactors the related logic.