### PR TITLE
fix!: `signed` backward compatibility priority

### DIFF
--- a/src/netlify-config-parser.js
+++ b/src/netlify-config-parser.js
@@ -27,9 +27,9 @@ function redirectMatch({
   parameters = {},
   params = parameters,
   query = params,
-  signed,
-  signing = signed,
-  sign = signing,
+  sign,
+  signing = sign,
+  signed = signing,
 }) {
   const { scheme, host, path, reason } = parseFrom(from)
   if (reason !== undefined) {
@@ -60,7 +60,7 @@ function redirectMatch({
     force,
     conditions,
     headers,
-    signed: sign,
+    signed,
   }
 }
 


### PR DESCRIPTION
`signed` has been renamed several times. The latest name is `signed` so it should have the priority.
Also, backward compatibility is slightly different depending on whether `_redirects` or `netlify.toml` is used.