### PR TITLE
feat!: use exceptions

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -2,14 +2,6 @@ const { URL } = require('url')
 
 const filterObj = require('filter-obj')
 
-function addSuccess(result, object) {
-  return { ...result, success: [...result.success, object] }
-}
-
-function addError(result, object) {
-  return { ...result, errors: [...result.errors, object] }
-}
-
 function isInvalidSource(path) {
   return path.startsWith('/.netlify')
 }
@@ -26,7 +18,7 @@ function isProxy({ status, to }) {
 
 function parseFrom(from) {
   if (from === undefined) {
-    return { reason: 'Missing source path/URL' }
+    throw new Error('Missing source path/URL')
   }
 
   if (!isUrl(from)) {
@@ -38,7 +30,7 @@ function parseFrom(from) {
     const scheme = protocol.slice(0, -1)
     return { scheme, host, path }
   } catch (error) {
-    return { reason: `Invalid URL: ${error.message}` }
+    throw new Error(`Invalid URL: ${error.message}`)
   }
 }
 
@@ -55,8 +47,6 @@ function removeUndefinedValues(object) {
 }
 
 module.exports = {
-  addSuccess,
-  addError,
   isInvalidSource,
   isProxy,
   isUrl,

--- a/src/line-parser.test.js
+++ b/src/line-parser.test.js
@@ -7,8 +7,8 @@ const { parseRedirectsFormat } = require('.')
 const testFilesDir = path.resolve('__dirname', '../', 'test-files')
 
 test('simple redirects', async (t) => {
-  const result = await parseRedirectsFormat(path.resolve(testFilesDir, 'simple_redirects'))
-  t.deepEqual(result.success, [
+  const redirects = await parseRedirectsFormat(path.resolve(testFilesDir, 'simple_redirects'))
+  t.deepEqual(redirects, [
     { path: '/home', to: '/', proxy: false, force: false, query: {}, conditions: {}, headers: {}, edgeHandlers: [] },
     {
       path: '/blog/my-post.php',
@@ -44,8 +44,8 @@ test('simple redirects', async (t) => {
 })
 
 test('redirects with status codes', async (t) => {
-  const result = await parseRedirectsFormat(path.resolve(testFilesDir, 'status_code_redirects'))
-  t.deepEqual(result.success, [
+  const redirects = await parseRedirectsFormat(path.resolve(testFilesDir, 'status_code_redirects'))
+  t.deepEqual(redirects, [
     {
       path: '/home',
       to: '/',
@@ -94,8 +94,8 @@ test('redirects with status codes', async (t) => {
 })
 
 test('redirects with parameter matches', async (t) => {
-  const result = await parseRedirectsFormat(path.resolve(testFilesDir, 'parameter_match_redirects'))
-  t.deepEqual(result.success, [
+  const redirects = await parseRedirectsFormat(path.resolve(testFilesDir, 'parameter_match_redirects'))
+  t.deepEqual(redirects, [
     {
       path: '/',
       to: '/news',
@@ -131,8 +131,8 @@ test('redirects with parameter matches', async (t) => {
 })
 
 test('redirects with full hostname', async (t) => {
-  const result = await parseRedirectsFormat(path.resolve(testFilesDir, 'full_hostname_redirects'))
-  t.deepEqual(result.success, [
+  const redirects = await parseRedirectsFormat(path.resolve(testFilesDir, 'full_hostname_redirects'))
+  t.deepEqual(redirects, [
     {
       host: 'hello.bitballoon.com',
       scheme: 'http',
@@ -149,8 +149,8 @@ test('redirects with full hostname', async (t) => {
 })
 
 test('proxy instruction', async (t) => {
-  const result = await parseRedirectsFormat(path.resolve(testFilesDir, 'proxy_redirects'))
-  t.deepEqual(result.success, [
+  const redirects = await parseRedirectsFormat(path.resolve(testFilesDir, 'proxy_redirects'))
+  t.deepEqual(redirects, [
     {
       path: '/api/*',
       to: 'https://api.bitballoon.com/*',
@@ -166,8 +166,8 @@ test('proxy instruction', async (t) => {
 })
 
 test('redirect with country conditions', async (t) => {
-  const result = await parseRedirectsFormat(path.resolve(testFilesDir, 'country_redirects'))
-  t.deepEqual(result.success, [
+  const redirects = await parseRedirectsFormat(path.resolve(testFilesDir, 'country_redirects'))
+  t.deepEqual(redirects, [
     {
       path: '/',
       to: '/china',
@@ -183,8 +183,8 @@ test('redirect with country conditions', async (t) => {
 })
 
 test('redirect with country and language conditions', async (t) => {
-  const result = await parseRedirectsFormat(path.resolve(testFilesDir, 'country_language_redirects'))
-  t.deepEqual(result.success, [
+  const redirects = await parseRedirectsFormat(path.resolve(testFilesDir, 'country_language_redirects'))
+  t.deepEqual(redirects, [
     {
       path: '/',
       to: '/china',
@@ -200,8 +200,8 @@ test('redirect with country and language conditions', async (t) => {
 })
 
 test('splat based redirect with no force instruction', async (t) => {
-  const result = await parseRedirectsFormat(path.resolve(testFilesDir, 'splat_no_force_redirects'))
-  t.deepEqual(result.success, [
+  const redirects = await parseRedirectsFormat(path.resolve(testFilesDir, 'splat_no_force_redirects'))
+  t.deepEqual(redirects, [
     {
       path: '/*',
       to: 'https://www.bitballoon.com/:splat',
@@ -217,8 +217,8 @@ test('splat based redirect with no force instruction', async (t) => {
 })
 
 test('splat based redirect with force instruction', async (t) => {
-  const result = await parseRedirectsFormat(path.resolve(testFilesDir, 'splat_force_redirects'))
-  t.deepEqual(result.success, [
+  const redirects = await parseRedirectsFormat(path.resolve(testFilesDir, 'splat_force_redirects'))
+  t.deepEqual(redirects, [
     {
       path: '/*',
       to: 'https://www.bitballoon.com/:splat',
@@ -234,8 +234,8 @@ test('splat based redirect with force instruction', async (t) => {
 })
 
 test('redirect rule with equal', async (t) => {
-  const result = await parseRedirectsFormat(path.resolve(testFilesDir, 'equal_redirects'))
-  t.deepEqual(result.success, [
+  const redirects = await parseRedirectsFormat(path.resolve(testFilesDir, 'equal_redirects'))
+  t.deepEqual(redirects, [
     {
       path: '/test',
       to: 'https://www.bitballoon.com/test=hello',
@@ -251,8 +251,8 @@ test('redirect rule with equal', async (t) => {
 })
 
 test('some real world edge case rules', async (t) => {
-  const result = await parseRedirectsFormat(path.resolve(testFilesDir, 'realworld_redirects'))
-  t.deepEqual(result.success, [
+  const redirects = await parseRedirectsFormat(path.resolve(testFilesDir, 'realworld_redirects'))
+  t.deepEqual(redirects, [
     {
       path: '/donate',
       to: '/donate/usa?source=:source&email=:email',
@@ -290,42 +290,36 @@ test('some real world edge case rules', async (t) => {
 })
 
 test('rules with no destination', async (t) => {
-  const result = await parseRedirectsFormat(path.resolve(testFilesDir, 'no_destination_redirects'))
-  t.is(result.success.length, 0)
-  t.is(result.errors.length, 1)
+  await t.throwsAsync(
+    parseRedirectsFormat(path.resolve(testFilesDir, 'no_destination_redirects')),
+    /Missing destination/,
+  )
 })
 
 test('rules with complex redirects', async (t) => {
-  const result = await parseRedirectsFormat(path.resolve(testFilesDir, 'complex_redirects'))
-  t.is(result.errors.length, 0)
-  t.is(result.success.length, 1)
+  const redirects = await parseRedirectsFormat(path.resolve(testFilesDir, 'complex_redirects'))
+  t.is(redirects.length, 1)
   t.is(
-    result.success[0].to,
+    redirects[0].to,
     'https://goo.gl/app/playmusic?ibi=com.google.PlayMusic&isi=691797987&ius=googleplaymusic&link=https://play.google.com/music/m/Ihj4yege3lfmp3vs5yoopgxijpi?t%3DArrested_DevOps',
   )
 })
 
 test('complicated _redirects file', async (t) => {
-  const result = await parseRedirectsFormat(path.resolve(testFilesDir, 'complicated_redirects'))
-  t.is(result.errors.length, 0)
-  t.is(result.success.length, 26)
-  result.success.forEach((rule) => {
+  const redirects = await parseRedirectsFormat(path.resolve(testFilesDir, 'complicated_redirects'))
+  t.is(redirects.length, 26)
+  redirects.forEach((rule) => {
     t.regex(rule.to, /^http/)
   })
 })
 
 test('long _redirects file', async (t) => {
-  const result = await parseRedirectsFormat(path.resolve(testFilesDir, 'redirects'))
-  t.deepEqual(
-    result.errors.map(({ lineNum }) => lineNum),
-    [640, 734, 917, 918, 919, 920, 987],
-  )
-  t.true(result.success.length !== 0)
+  await t.throwsAsync(parseRedirectsFormat(path.resolve(testFilesDir, 'redirects')), /Missing source or destination/)
 })
 
 test('redirect with proxy signing', async (t) => {
-  const result = await parseRedirectsFormat(path.resolve(testFilesDir, 'proxy_signing_redirects'))
-  t.deepEqual(result.success[0], {
+  const redirects = await parseRedirectsFormat(path.resolve(testFilesDir, 'proxy_signing_redirects'))
+  t.deepEqual(redirects[0], {
     path: '/api/*',
     to: 'https://api.example.com/:splat',
     status: 200,
@@ -340,8 +334,8 @@ test('redirect with proxy signing', async (t) => {
 })
 
 test('absolute redirects with country condition', async (t) => {
-  const result = await parseRedirectsFormat(path.resolve(testFilesDir, 'absolute_country_redirects'))
-  t.deepEqual(result.success[0], {
+  const redirects = await parseRedirectsFormat(path.resolve(testFilesDir, 'absolute_country_redirects'))
+  t.deepEqual(redirects[0], {
     host: 'ximble.com.au',
     scheme: 'http',
     path: '/*',
@@ -357,8 +351,8 @@ test('absolute redirects with country condition', async (t) => {
 })
 
 test('redirect role conditions', async (t) => {
-  const result = await parseRedirectsFormat(path.resolve(testFilesDir, 'role_condition_redirects'))
-  t.deepEqual(result.success, [
+  const redirects = await parseRedirectsFormat(path.resolve(testFilesDir, 'role_condition_redirects'))
+  t.deepEqual(redirects, [
     {
       path: '/admin/*',
       to: '/admin/:splat',
@@ -374,8 +368,8 @@ test('redirect role conditions', async (t) => {
 })
 
 test('redirect with multiple roles', async (t) => {
-  const result = await parseRedirectsFormat(path.resolve(testFilesDir, 'multiple_roles_redirects'))
-  t.deepEqual(result.success, [
+  const redirects = await parseRedirectsFormat(path.resolve(testFilesDir, 'multiple_roles_redirects'))
+  t.deepEqual(redirects, [
     {
       path: '/member/*',
       to: '/member/:splat',
@@ -391,8 +385,8 @@ test('redirect with multiple roles', async (t) => {
 })
 
 test('parse forward rule', async (t) => {
-  const result = await parseRedirectsFormat(path.resolve(testFilesDir, 'path_forward_redirects'))
-  t.deepEqual(result.success, [
+  const redirects = await parseRedirectsFormat(path.resolve(testFilesDir, 'path_forward_redirects'))
+  t.deepEqual(redirects, [
     {
       path: '/admin/*',
       to: '/admin/:splat',
@@ -419,12 +413,13 @@ test('parse forward rule', async (t) => {
 })
 
 test('parse mistaken _headers file', async (t) => {
-  const result = await parseRedirectsFormat(path.resolve(testFilesDir, 'mistaken_headers'))
-  t.is(result.errors.length, 2)
+  await t.throwsAsync(
+    parseRedirectsFormat(path.resolve(testFilesDir, 'mistaken_headers')),
+    /Missing source or destination/,
+  )
 })
 
 test('valid service destination path', async (t) => {
-  const result = await parseRedirectsFormat(path.resolve(testFilesDir, 'service_redirects'))
-  t.is(result.errors.length, 0)
-  t.is(result.success.length, 1)
+  const redirects = await parseRedirectsFormat(path.resolve(testFilesDir, 'service_redirects'))
+  t.is(redirects.length, 1)
 })

--- a/src/netlify-config-parser.test.js
+++ b/src/netlify-config-parser.test.js
@@ -7,8 +7,8 @@ const { parseNetlifyConfig } = require('.')
 const testFilesDir = path.resolve('__dirname', '../', 'test-files')
 
 test('netlify.toml redirects parsing', async (t) => {
-  const result = await parseNetlifyConfig(path.resolve(testFilesDir, 'netlify.toml'))
-  t.deepEqual(result.success, [
+  const redirects = await parseNetlifyConfig(path.resolve(testFilesDir, 'netlify.toml'))
+  t.deepEqual(redirects, [
     {
       path: '/old-path',
       to: '/new-path',


### PR DESCRIPTION
The current code is returning error objects instead of throwing exceptions.

The main advantage is that this returns all parsing errors instead of only the first one. 
  - However, in most cases, users write their configuration files (such as redirects) incrementally, not all at once, so they are unlikely to introduce many syntax errors at once. 
  - Also, it is possible that several parsing errors are in fact a single one. In that case, reporting all of them would actually be detrimental. For example, if a user is using `/* */` multiline comments in `_redirects`, this is a single syntax error but might currently reported as many errors.

Instead, this PR switches to throwing exceptions instead. This has the following advantages:
  - Consistency with our other projects (CLI, `@netlify/config`, etc.) which use exceptions too
  - Simpler DX: instead of returning an object with two array properties, this now only returns a single array
  - Performance: do not keep parsing the file if it's erroneous
  - More idiomatic in JavaScript
  - Simplifies implementation since it removes the need for `if (error) { return error }` statements