### PR TITLE
fix: allow non-force forward rules

### DIFF
--- a/src/netlify-config-parser.js
+++ b/src/netlify-config-parser.js
@@ -44,7 +44,7 @@ const redirectMatch = function ({
 }) {
   const { scheme, host, path } = parseFrom(from)
 
-  const finalTo = splatForwardRule(path, status, force, to) ? path.replace(/\/\*$/, '/:splat') : to
+  const finalTo = splatForwardRule(path, status, to) ? path.replace(/\/\*$/, '/:splat') : to
 
   if (finalTo === undefined) {
     throw new Error('Missing "to" field')
@@ -69,8 +69,8 @@ const redirectMatch = function ({
   }
 }
 
-const splatForwardRule = function (path, status, force, to) {
-  return to === undefined && force && isSplatRule(path, status)
+const splatForwardRule = function (path, status, to) {
+  return to === undefined && isSplatRule(path, status)
 }
 
 module.exports = { parseNetlifyConfig }


### PR DESCRIPTION
Non-force forward rules are allowed with `_redirects` but not with `netlify.toml`.

I have tracked down changes to this file and it seemed like this change of behavior was introduced by https://github.com/netlify/cli/pull/518. However, it looks like that PR was not not meant to do so and this is a bug.

Forbidding non-force forward rules does not seem to make sense. Also, any users currently using non-force forward rules in `netlify.toml` should experience syntax error validation, so allowing it should only improve behavior (as opposed to make currently existing sites fail).