### PR TITLE
fix: validation of `from`

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -7,10 +7,6 @@ const isProxy = function ({ status, to }) {
 }
 
 const parseFrom = function (from) {
-  if (from === undefined) {
-    throw new Error('Missing source path/URL')
-  }
-
   const { scheme, host, path } = parseFromField(from)
   if (path.startsWith('/.netlify')) {
     throw new Error('"path" field must not start with "/.netlify"')

--- a/src/line-parser.js
+++ b/src/line-parser.js
@@ -30,11 +30,12 @@ ${error.message}`)
 
 const redirectMatch = function (line) {
   const [from, ...parts] = trimComment(line.split(LINE_TOKENS_REGEXP))
-  if (parts.length === 0) {
-    throw new Error('Missing source or destination path/URL')
-  }
 
   const { scheme, host, path } = parseFrom(from)
+
+  if (parts.length === 0) {
+    throw new Error('Missing destination path/URL')
+  }
 
   if (splatForwardRule(path, parts[0])) {
     const to = path.replace(/\/\*$/, '/:splat')

--- a/src/netlify-config-parser.js
+++ b/src/netlify-config-parser.js
@@ -41,6 +41,10 @@ const redirectMatch = function ({
   signing = sign,
   signed = signing,
 }) {
+  if (from === undefined) {
+    throw new Error('Missing "from" field')
+  }
+
   const { scheme, host, path } = parseFrom(from)
 
   const finalTo = splatForwardRule(path, status, to) ? path.replace(/\/\*$/, '/:splat') : to

--- a/tests/line-parser.js
+++ b/tests/line-parser.js
@@ -147,8 +147,8 @@ each(
 each(
   [
     { title: 'no_destination_redirects', errorMessage: /Missing destination/ },
-    { title: 'redirects', errorMessage: /Missing source or destination/ },
-    { title: 'mistaken_headers', errorMessage: /Missing source or destination/ },
+    { title: 'redirects', errorMessage: /Missing destination/ },
+    { title: 'mistaken_headers', errorMessage: /Missing destination/ },
   ],
   ({ title }, { fixtureName = title, errorMessage }) => {
     test(`Validate syntax errors | ${title}`, async (t) => {


### PR DESCRIPTION
We validate when the `from` field is missing.

However, since empty lines or lines with only comments are valid, this can only happen when using redirects in `netlify.toml` not inside `_redirects`. This PR fixes this.