### PR TITLE
chore: refactor forward rules

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -2,6 +2,22 @@ const { URL } = require('url')
 
 const filterObj = require('filter-obj')
 
+const isSplatRule = function (from, status) {
+  return from.endsWith('/*') && status >= 200 && status < 300
+}
+
+const replaceSplatRule = function (from) {
+  return from.replace(SPLAT_REGEXP, '/:splat')
+}
+
+const SPLAT_REGEXP = /\/\*$/
+
+const finalizeRedirect = function ({ from, ...redirect }) {
+  const { scheme, host, path } = parseFrom(from)
+  const proxy = isProxy(redirect)
+  return removeUndefinedValues({ ...redirect, scheme, host, path, proxy })
+}
+
 const parseFrom = function (from) {
   const { scheme, host, path } = parseFromField(from)
   if (path.startsWith('/.netlify')) {
@@ -31,21 +47,6 @@ const isUrl = function (pathOrUrl) {
 
 const SCHEMES = ['http://', 'https://']
 
-const isSplatRule = function (path, status) {
-  return path.endsWith('/*') && status >= 200 && status < 300
-}
-
-const replaceSplatRule = function (path) {
-  return path.replace(SPLAT_REGEXP, '/:splat')
-}
-
-const SPLAT_REGEXP = /\/\*$/
-
-const finalizeRedirect = function (redirect) {
-  const proxy = isProxy(redirect)
-  return removeUndefinedValues({ ...redirect, proxy })
-}
-
 const isProxy = function ({ status, to }) {
   return status === 200 && isUrl(to)
 }
@@ -62,6 +63,5 @@ module.exports = {
   isUrl,
   isSplatRule,
   replaceSplatRule,
-  parseFrom,
   finalizeRedirect,
 }

--- a/src/netlify-config-parser.js
+++ b/src/netlify-config-parser.js
@@ -1,7 +1,7 @@
 const resolveConfig = require('@netlify/config')
 const isPlainObj = require('is-plain-obj')
 
-const { parseFrom, isSplatRule, replaceSplatRule, finalizeRedirect } = require('./common')
+const { isSplatRule, replaceSplatRule, finalizeRedirect } = require('./common')
 
 const parseNetlifyConfig = async function (config) {
   const {
@@ -49,18 +49,14 @@ const parseRedirectObject = function ({
     throw new Error('Missing "from" field')
   }
 
-  const { scheme, host, path } = parseFrom(from)
-
-  const finalTo = addForwardRule(path, status, to)
-
   if (!isPlainObj(headers)) {
     throw new Error('"headers" field must be an object')
   }
 
+  const finalTo = addForwardRule(from, status, to)
+
   return {
-    host,
-    scheme,
-    path,
+    from,
     to: finalTo,
     query,
     status,
@@ -71,16 +67,16 @@ const parseRedirectObject = function ({
   }
 }
 
-const addForwardRule = function (path, status, to) {
+const addForwardRule = function (from, status, to) {
   if (to !== undefined) {
     return to
   }
 
-  if (!isSplatRule(path, status)) {
+  if (!isSplatRule(from, status)) {
     throw new Error('Missing "to" field')
   }
 
-  return replaceSplatRule(path)
+  return replaceSplatRule(from)
 }
 
 module.exports = { parseNetlifyConfig }


### PR DESCRIPTION
This removes more duplicate code by refactoring forward rules.

This applies forward rules before URL parsing, which is ok since the forward rules logic only changes the end of the string from `/*` to `/:splat` which works for both file paths and URLs.