### PR TITLE
feat: validate that `redirects` is an array

### DIFF
--- a/src/netlify-config-parser.js
+++ b/src/netlify-config-parser.js
@@ -7,12 +7,17 @@ const parseNetlifyConfig = async function (config) {
   const {
     config: { redirects = [] },
   } = await resolveConfig({ config })
+
+  if (!Array.isArray(redirects)) {
+    throw new TypeError(`Redirects must be an array not: ${redirects}`)
+  }
+
   return redirects.map(parseRedirect).map(finalizeRedirect)
 }
 
 const parseRedirect = function (obj, index) {
   if (!isPlainObj(obj)) {
-    throw new Error(`Redirects must be objects not: ${obj}`)
+    throw new TypeError(`Redirects must be objects not: ${obj}`)
   }
 
   try {


### PR DESCRIPTION
This validates that `redirects` is an array inside `netlify.toml`.

Using `[redirects]` instead of `[[redirects]]` is a likely mistake.