### PR TITLE
chore: default `force` to `false`

### DIFF
--- a/src/netlify-config-parser.js
+++ b/src/netlify-config-parser.js
@@ -26,7 +26,7 @@ ${error.message}`)
 
 const redirectMatch = function ({
   status,
-  force,
+  force = false,
   conditions = {},
   headers = {},
   origin,


### PR DESCRIPTION
This defaults `force` to `false` when parsing `netlify.toml`.