### PR TITLE
chore: remove Edge handlers parsing

### DIFF
--- a/src/line-parser.js
+++ b/src/line-parser.js
@@ -46,7 +46,7 @@ const redirectMatch = function (line) {
   const query = parsePairs(newParts.slice(0, newHostPartIndex))
   const to = newParts[newHostPartIndex]
   const { status, force, conditions, signed } = parseLastParts(newParts.slice(newHostPartIndex + 1))
-  return { to, scheme, host, path, status, force, query, conditions, headers: {}, edgeHandlers: [], signed }
+  return { to, scheme, host, path, status, force, query, conditions, headers: {}, signed }
 }
 
 const trimComment = function (parts) {

--- a/src/netlify-config-parser.js
+++ b/src/netlify-config-parser.js
@@ -36,7 +36,6 @@ const redirectMatch = function ({
   parameters = {},
   params = parameters,
   query = params,
-  edge_handlers: edgeHandlers = [],
   sign,
   signing = sign,
   signed = signing,
@@ -63,7 +62,6 @@ const redirectMatch = function ({
     force,
     conditions,
     headers,
-    edgeHandlers,
     signed,
   }
 }

--- a/tests/helpers/main.js
+++ b/tests/helpers/main.js
@@ -11,7 +11,6 @@ const DEFAULT_REDIRECT = {
   query: {},
   conditions: {},
   headers: {},
-  edgeHandlers: [],
 }
 
 module.exports = { FIXTURES_DIR, normalizeRedirect }


### PR DESCRIPTION
In #196, I misread the new syntax for Edge handlers.
Edge handlers now have their own top-level property in `netlify.toml`, i.e. should be parsed separately from redirects.