### PR TITLE
feat: allow `_redirects` to be optional

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "@netlify/config": "^6.9.2",
         "filter-obj": "^2.0.2",
-        "is-plain-obj": "^2.1.0"
+        "is-plain-obj": "^2.1.0",
+        "path-exists": "^4.0.0"
       },
       "devDependencies": {
         "@netlify/eslint-config-node": "^3.1.3",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
   "dependencies": {
     "@netlify/config": "^6.9.2",
     "filter-obj": "^2.0.2",
-    "is-plain-obj": "^2.1.0"
+    "is-plain-obj": "^2.1.0",
+    "path-exists": "^4.0.0"
   },
   "devDependencies": {
     "@netlify/eslint-config-node": "^3.1.3",

--- a/src/line_parser.js
+++ b/src/line_parser.js
@@ -1,6 +1,8 @@
 const fs = require('fs')
 const { promisify } = require('util')
 
+const pathExists = require('path-exists')
+
 const { isUrl, isSplatRule, replaceSplatRule, finalizeRedirect } = require('./common')
 
 const readFileAsync = promisify(fs.readFile)
@@ -24,6 +26,10 @@ const readFileAsync = promisify(fs.readFile)
 // Unlike "redirects" in "netlify.toml", the "headers" and "edge_handlers"
 // cannot be specified.
 const parseRedirectsFormat = async function (filePath) {
+  if (!(await pathExists(filePath))) {
+    return []
+  }
+
   const text = await readFileAsync(filePath, 'utf-8')
   return text.split('\n').map(normalizeLine).filter(hasRedirect).map(parseRedirect).map(finalizeRedirect)
 }

--- a/tests/line_parser.js
+++ b/tests/line_parser.js
@@ -16,6 +16,10 @@ each(
       output: [],
     },
     {
+      title: 'non_existing',
+      output: [],
+    },
+    {
       title: 'empty_line',
       output: [
         { path: '/blog/my-post.php', to: '/blog/my-post' },


### PR DESCRIPTION
Part of https://github.com/netlify/build/issues/2889

This allows the `_redirects` file to be optional.
This will be useful for `@netlify/config` so it does not need to perform that check.