### PR TITLE
feat: add logic to merge redirects

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 const { parseRedirectsFormat } = require('./line_parser')
+const { mergeRedirects } = require('./merge')
 const { parseNetlifyConfig } = require('./netlify_config_parser')
 
-module.exports = { parseRedirectsFormat, parseNetlifyConfig }
+module.exports = { parseRedirectsFormat, parseNetlifyConfig, mergeRedirects }

--- a/src/merge.js
+++ b/src/merge.js
@@ -1,0 +1,12 @@
+// Merge redirects from `_redirects` with the ones from `netlify.toml`.
+// When both are specified, both are used and `_redirects` has priority.
+// Since in both `netlify.toml` and `_redirects`, only the first matching rule
+// is used, it is possible to merge `_redirects` to `netlify.toml` by prepending
+// its rules to `netlify.toml` `redirects` field.
+// This function implements this logic. It is very simple, but it allows
+// changing the merging logic later.
+const mergeRedirects = function ({ fileRedirects, configRedirects }) {
+  return [...fileRedirects, ...configRedirects]
+}
+
+module.exports = { mergeRedirects }

--- a/tests/merge.js
+++ b/tests/merge.js
@@ -1,0 +1,25 @@
+const test = require('ava')
+const { each } = require('test-each')
+
+const { mergeRedirects } = require('..')
+
+each(
+  [
+    { fileRedirects: [], configRedirects: [], output: [] },
+    { fileRedirects: [{ from: '/one', to: '/two' }], configRedirects: [], output: [{ from: '/one', to: '/two' }] },
+    { fileRedirects: [], configRedirects: [{ from: '/one', to: '/three' }], output: [{ from: '/one', to: '/three' }] },
+    {
+      fileRedirects: [{ from: '/one', to: '/two' }],
+      configRedirects: [{ from: '/one', to: '/three' }],
+      output: [
+        { from: '/one', to: '/two' },
+        { from: '/one', to: '/three' },
+      ],
+    },
+  ],
+  ({ title }, { fileRedirects, configRedirects, output }) => {
+    test(`Merges _redirects with netlify.toml redirects | ${title}`, (t) => {
+      t.deepEqual(mergeRedirects({ fileRedirects, configRedirects }), output)
+    })
+  },
+)


### PR DESCRIPTION
Part of https://github.com/netlify/build/issues/2889

This adds some logic to merge redirects.

The logic looks so simple one might think we should not bother. However, this provides with abstraction, allowing us to change the merging logic in a single place later. Also, just figuring out what the merging logic was took me some time, and the code comments themselves can be useful.