### PR TITLE
feat: add `parseAllRedirects()`

### DIFF
--- a/src/all.js
+++ b/src/all.js
@@ -1,0 +1,31 @@
+const { parseFileRedirects } = require('./line_parser')
+const { mergeRedirects } = require('./merge')
+const { parseConfigRedirects } = require('./netlify_config_parser')
+const { normalizeRedirects } = require('./normalize')
+
+// Parse all redirects from `netlify.toml` and `_redirects` file, then normalize
+// and validate those.
+const parseAllRedirects = async function ({ redirectsFiles = [], netlifyConfigPath } = {}) {
+  const [fileRedirects, configRedirects] = await Promise.all([
+    getFileRedirects(redirectsFiles),
+    getConfigRedirects(netlifyConfigPath),
+  ])
+  const redirects = mergeRedirects({ fileRedirects, configRedirects })
+  return normalizeRedirects(redirects)
+}
+
+const getFileRedirects = async function (redirectsFiles) {
+  const fileRedirects = await Promise.all(redirectsFiles.map(parseFileRedirects))
+  // eslint-disable-next-line unicorn/prefer-spread
+  return [].concat(...fileRedirects)
+}
+
+const getConfigRedirects = async function (netlifyConfigPath) {
+  if (netlifyConfigPath === undefined) {
+    return []
+  }
+
+  return await parseConfigRedirects(netlifyConfigPath)
+}
+
+module.exports = { parseAllRedirects }

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,13 @@
+const { parseAllRedirects } = require('./all')
 const { parseFileRedirects } = require('./line_parser')
 const { mergeRedirects } = require('./merge')
 const { parseConfigRedirects } = require('./netlify_config_parser')
 const { normalizeRedirects } = require('./normalize')
 
-module.exports = { parseFileRedirects, parseConfigRedirects, mergeRedirects, normalizeRedirects }
+module.exports = {
+  parseAllRedirects,
+  parseFileRedirects,
+  mergeRedirects,
+  parseConfigRedirects,
+  normalizeRedirects,
+}

--- a/src/line_parser.js
+++ b/src/line_parser.js
@@ -25,12 +25,12 @@ const readFileAsync = promisify(fs.readFile)
 //     - "Sign" is a special condition
 // Unlike "redirects" in "netlify.toml", the "headers" and "edge_handlers"
 // cannot be specified.
-const parseFileRedirects = async function (filePath) {
-  if (!(await pathExists(filePath))) {
+const parseFileRedirects = async function (redirectFile) {
+  if (!(await pathExists(redirectFile))) {
     return []
   }
 
-  const text = await readFileAsync(filePath, 'utf-8')
+  const text = await readFileAsync(redirectFile, 'utf-8')
   return text.split('\n').map(normalizeLine).filter(hasRedirect).map(parseRedirect)
 }
 

--- a/src/netlify_config_parser.js
+++ b/src/netlify_config_parser.js
@@ -9,12 +9,12 @@ const pReadFile = promisify(readFile)
 // Parse `redirects` field in "netlify.toml" to an array of objects.
 // This field is already an array of objects so it only validates and
 // normalizes it.
-const parseConfigRedirects = async function (configPath) {
-  if (!(await pathExists(configPath))) {
+const parseConfigRedirects = async function (netlifyConfigPath) {
+  if (!(await pathExists(netlifyConfigPath))) {
     return []
   }
 
-  const { redirects = [] } = await parseConfig(configPath)
+  const { redirects = [] } = await parseConfig(netlifyConfigPath)
   return redirects
 }
 

--- a/tests/all.js
+++ b/tests/all.js
@@ -1,0 +1,109 @@
+const test = require('ava')
+const { each } = require('test-each')
+
+const { parseAllRedirects } = require('..')
+
+const { FIXTURES_DIR } = require('./helpers/main')
+
+const parseRedirects = async function ({ fileFixtureNames, configFixtureName }) {
+  const redirectsFiles =
+    fileFixtureNames === undefined
+      ? undefined
+      : fileFixtureNames.map((fileFixtureName) => `${FIXTURES_DIR}/redirects_file/${fileFixtureName}`)
+  const netlifyConfigPath =
+    configFixtureName === undefined ? undefined : `${FIXTURES_DIR}/netlify_config/${configFixtureName}.toml`
+  const options =
+    redirectsFiles === undefined && netlifyConfigPath === undefined ? undefined : { redirectsFiles, netlifyConfigPath }
+  return await parseAllRedirects(options)
+}
+
+each(
+  [
+    {
+      title: 'empty',
+      output: [],
+    },
+    {
+      title: 'only_config',
+      configFixtureName: 'from_simple',
+      output: [
+        {
+          path: '/old-path',
+          query: {},
+          to: '/new-path',
+          force: false,
+          conditions: {},
+          headers: {},
+          proxy: false,
+        },
+      ],
+    },
+    {
+      title: 'only_files',
+      fileFixtureNames: ['from_simple', 'from_absolute_uri'],
+      output: [
+        {
+          path: '/home',
+          query: {},
+          to: '/',
+          force: false,
+          conditions: {},
+          headers: {},
+          proxy: false,
+        },
+        {
+          scheme: 'http',
+          host: 'hello.bitballoon.com',
+          path: '/*',
+          query: {},
+          to: 'http://www.hello.com/:splat',
+          force: false,
+          conditions: {},
+          headers: {},
+          proxy: false,
+        },
+      ],
+    },
+    {
+      title: 'both_config_files',
+      fileFixtureNames: ['from_simple', 'from_absolute_uri'],
+      configFixtureName: 'from_simple',
+      output: [
+        {
+          path: '/home',
+          query: {},
+          to: '/',
+          force: false,
+          conditions: {},
+          headers: {},
+          proxy: false,
+        },
+        {
+          scheme: 'http',
+          host: 'hello.bitballoon.com',
+          path: '/*',
+          query: {},
+          to: 'http://www.hello.com/:splat',
+          force: false,
+          conditions: {},
+          headers: {},
+          proxy: false,
+        },
+        {
+          path: '/old-path',
+          query: {},
+          to: '/new-path',
+          force: false,
+          conditions: {},
+          headers: {},
+          proxy: false,
+        },
+      ],
+    },
+  ],
+  ({ title }, { fileFixtureNames, configFixtureName, output }) => {
+    test(`Parses netlify.toml and _redirects | ${title}`, async (t) => {
+      t.deepEqual(await parseRedirects({ fileFixtureNames, configFixtureName }), output)
+    })
+  },
+)


### PR DESCRIPTION
This creates a `parseAllRedirects()` method which parses both `netlify.toml` and `_redirects`, and normalize/validate the result.
This will be used by Netlify CLI, removing some code there which is currently doing this.