### PR TITLE
feat: improve redirects merging

### DIFF
--- a/src/merge.js
+++ b/src/merge.js
@@ -1,3 +1,5 @@
+const { inspect } = require('util')
+
 // Merge redirects from `_redirects` with the ones from `netlify.toml`.
 // When both are specified, both are used and `_redirects` has priority.
 // Since in both `netlify.toml` and `_redirects`, only the first matching rule
@@ -5,8 +7,16 @@
 // its rules to `netlify.toml` `redirects` field.
 // This function implements this logic. It is very simple, but it allows
 // changing the merging logic later.
-const mergeRedirects = function ({ fileRedirects, configRedirects }) {
+const mergeRedirects = function ({ fileRedirects = [], configRedirects = [] }) {
+  validateArray(fileRedirects)
+  validateArray(configRedirects)
   return [...fileRedirects, ...configRedirects]
+}
+
+const validateArray = function (redirects) {
+  if (!Array.isArray(redirects)) {
+    throw new TypeError(`Redirects should be an array: ${inspect(redirects, { colors: false })}`)
+  }
 }
 
 module.exports = { mergeRedirects }

--- a/tests/merge.js
+++ b/tests/merge.js
@@ -5,6 +5,7 @@ const { mergeRedirects } = require('..')
 
 each(
   [
+    { output: [] },
     { fileRedirects: [], configRedirects: [], output: [] },
     { fileRedirects: [{ from: '/one', to: '/two' }], configRedirects: [], output: [{ from: '/one', to: '/two' }] },
     { fileRedirects: [], configRedirects: [{ from: '/one', to: '/three' }], output: [{ from: '/one', to: '/three' }] },
@@ -20,6 +21,18 @@ each(
   ({ title }, { fileRedirects, configRedirects, output }) => {
     test(`Merges _redirects with netlify.toml redirects | ${title}`, (t) => {
       t.deepEqual(mergeRedirects({ fileRedirects, configRedirects }), output)
+    })
+  },
+)
+
+each(
+  [
+    { fileRedirects: { from: '/one', to: '/three' }, errorMessage: /should be an array/ },
+    { configRedirects: { from: '/one', to: '/three' }, errorMessage: /should be an array/ },
+  ],
+  ({ title }, { fileRedirects, configRedirects, errorMessage }) => {
+    test(`Validate syntax errors | ${title}`, async (t) => {
+      await t.throws(mergeRedirects.bind(undefined, { fileRedirects, configRedirects }), errorMessage)
     })
   },
 )


### PR DESCRIPTION
This improves how redirects from `_redirects` and `netlify.toml` are merged:
  - Add default values
  - Add more validation