### PR TITLE
chore: add more tests

### DIFF
--- a/tests/fixtures/netlify_config/from_no_slash.toml
+++ b/tests/fixtures/netlify_config/from_no_slash.toml
@@ -1,0 +1,3 @@
+[[redirects]]
+  from = "old-path"
+  to = "new-path"

--- a/tests/fixtures/redirects_file/invalid_no_slash
+++ b/tests/fixtures/redirects_file/invalid_no_slash
@@ -1,0 +1,3 @@
+/	index.html
+/blog	blog.html
+/trt-therapy-san-diego	trt-therapy-san-diego.html

--- a/tests/line_parser.js
+++ b/tests/line_parser.js
@@ -163,6 +163,7 @@ each(
     { title: 'invalid_no_to_no_status', errorMessage: /Missing destination/ },
     { title: 'invalid_no_to_status', errorMessage: /Missing "to" field/ },
     { title: 'invalid_no_to_query', errorMessage: /Missing destination/ },
+    { title: 'invalid_no_slash', errorMessage: /Missing destination/ },
     { title: 'invalid_mistaken_headers', errorMessage: /Missing destination/ },
   ],
   ({ title }, { fixtureName = title, errorMessage }) => {

--- a/tests/netlify_config_parser.js
+++ b/tests/netlify_config_parser.js
@@ -57,6 +57,10 @@ each(
       output: [{ path: '/old-path/*', to: '/old-path/:splat', status: 200 }],
     },
     {
+      title: 'from_no_slash',
+      output: [{ path: 'old-path', to: 'new-path' }],
+    },
+    {
       title: 'query',
       output: [{ path: '/old-path', to: '/new-path', query: { path: ':path' } }],
     },


### PR DESCRIPTION
This adds more tests related to the following point: the leading `/` in paths is optional in `netlify.toml` but not in `_redirects`.