### PR TITLE
fix: add `origin` field

### DIFF
--- a/src/normalize.js
+++ b/src/normalize.js
@@ -63,7 +63,10 @@ const parseRedirectObject = function ({
   const { scheme, host, path } = parseFrom(from)
   const proxy = isProxy(status, finalTo)
 
+  // We ensure the return value has the same shape as our `netlify-commons`
+  // backend
   return removeUndefinedValues({
+    origin: from,
     scheme,
     host,
     path,

--- a/tests/all.js
+++ b/tests/all.js
@@ -28,6 +28,7 @@ each(
       configFixtureName: 'from_simple',
       output: [
         {
+          origin: '/old-path',
           path: '/old-path',
           query: {},
           to: '/new-path',
@@ -43,6 +44,7 @@ each(
       fileFixtureNames: ['from_simple', 'from_absolute_uri'],
       output: [
         {
+          origin: '/home',
           path: '/home',
           query: {},
           to: '/',
@@ -52,6 +54,7 @@ each(
           proxy: false,
         },
         {
+          origin: 'http://hello.bitballoon.com/*',
           scheme: 'http',
           host: 'hello.bitballoon.com',
           path: '/*',
@@ -70,6 +73,7 @@ each(
       configFixtureName: 'from_simple',
       output: [
         {
+          origin: '/home',
           path: '/home',
           query: {},
           to: '/',
@@ -79,6 +83,7 @@ each(
           proxy: false,
         },
         {
+          origin: 'http://hello.bitballoon.com/*',
           scheme: 'http',
           host: 'hello.bitballoon.com',
           path: '/*',
@@ -90,6 +95,7 @@ each(
           proxy: false,
         },
         {
+          origin: '/old-path',
           path: '/old-path',
           query: {},
           to: '/new-path',

--- a/tests/line_parser.js
+++ b/tests/line_parser.js
@@ -23,96 +23,249 @@ each(
     {
       title: 'empty_line',
       output: [
-        { path: '/blog/my-post.php', to: '/blog/my-post' },
-        { path: '/blog/my-post-two.php', to: '/blog/my-post-two' },
+        {
+          origin: '/blog/my-post.php',
+          path: '/blog/my-post.php',
+          to: '/blog/my-post',
+        },
+        {
+          origin: '/blog/my-post-two.php',
+          path: '/blog/my-post-two.php',
+          to: '/blog/my-post-two',
+        },
       ],
     },
     {
       title: 'multiple_lines',
       output: [
-        { path: '/10thmagnitude', to: 'http://www.10thmagnitude.com/', status: 301 },
-        { path: '/bananastand', to: 'http://eepurl.com/Lgde5', status: 301 },
+        {
+          origin: '/10thmagnitude',
+          path: '/10thmagnitude',
+          to: 'http://www.10thmagnitude.com/',
+          status: 301,
+        },
+        {
+          origin: '/bananastand',
+          path: '/bananastand',
+          to: 'http://eepurl.com/Lgde5',
+          status: 301,
+        },
       ],
     },
     {
       title: 'line_trim',
-      output: [{ path: '/home', to: '/' }],
+      output: [
+        {
+          origin: '/home',
+          path: '/home',
+          to: '/',
+        },
+      ],
     },
     {
       title: 'comment_full',
-      output: [{ path: '/blog/my-post.php', to: '/blog/my-post' }],
+      output: [
+        {
+          origin: '/blog/my-post.php',
+          path: '/blog/my-post.php',
+          to: '/blog/my-post',
+        },
+      ],
     },
     {
       title: 'comment_inline',
-      output: [{ path: '/blog/my-post.php', to: '/blog/my-post' }],
+      output: [
+        {
+          origin: '/blog/my-post.php',
+          path: '/blog/my-post.php',
+          to: '/blog/my-post',
+        },
+      ],
     },
     {
       title: 'from_simple',
-      output: [{ path: '/home', to: '/' }],
+      output: [
+        {
+          origin: '/home',
+          path: '/home',
+          to: '/',
+        },
+      ],
     },
     {
       title: 'from_absolute_uri',
-      output: [{ host: 'hello.bitballoon.com', scheme: 'http', path: '/*', to: 'http://www.hello.com/:splat' }],
+      output: [
+        {
+          origin: 'http://hello.bitballoon.com/*',
+          scheme: 'http',
+          host: 'hello.bitballoon.com',
+          path: '/*',
+          to: 'http://www.hello.com/:splat',
+        },
+      ],
     },
     {
       title: 'query',
       output: [
-        { path: '/', to: '/news', query: { page: 'news' } },
-        { path: '/blog', to: '/blog/:post_id', query: { post: ':post_id' } },
-        { path: '/', to: '/about', query: { _escaped_fragment_: '/about' } },
+        {
+          origin: '/',
+          path: '/',
+          to: '/news',
+          query: { page: 'news' },
+        },
+        {
+          origin: '/blog',
+          path: '/blog',
+          to: '/blog/:post_id',
+          query: { post: ':post_id' },
+        },
+        {
+          origin: '/',
+          path: '/',
+          to: '/about',
+          query: { _escaped_fragment_: '/about' },
+        },
       ],
     },
     {
       title: 'to_anchor',
-      output: [{ path: '/blog/my-post-ads.php', to: '/blog/my-post#ads' }],
+      output: [
+        {
+          origin: '/blog/my-post-ads.php',
+          path: '/blog/my-post-ads.php',
+          to: '/blog/my-post#ads',
+        },
+      ],
     },
     {
       title: 'to_splat_no_force',
-      output: [{ path: '/*', to: 'https://www.bitballoon.com/:splat', status: 301 }],
+      output: [
+        {
+          origin: '/*',
+          path: '/*',
+          to: 'https://www.bitballoon.com/:splat',
+          status: 301,
+        },
+      ],
     },
     {
       title: 'to_splat_force',
-      output: [{ path: '/*', to: 'https://www.bitballoon.com/:splat', status: 301, force: true }],
+      output: [
+        {
+          origin: '/*',
+          path: '/*',
+          to: 'https://www.bitballoon.com/:splat',
+          status: 301,
+          force: true,
+        },
+      ],
     },
     {
       title: 'to_path_forward',
       output: [
-        { path: '/admin/*', to: '/admin/:splat', status: 200 },
-        { path: '/admin/*', to: '/admin/:splat', status: 200, force: true },
+        {
+          origin: '/admin/*',
+          path: '/admin/*',
+          to: '/admin/:splat',
+          status: 200,
+        },
+        {
+          origin: '/admin/*',
+          path: '/admin/*',
+          to: '/admin/:splat',
+          status: 200,
+          force: true,
+        },
       ],
     },
     {
       title: 'proxy',
-      output: [{ path: '/api/*', to: 'https://api.bitballoon.com/*', status: 200, proxy: true }],
+      output: [
+        {
+          origin: '/api/*',
+          path: '/api/*',
+          to: 'https://api.bitballoon.com/*',
+          status: 200,
+          proxy: true,
+        },
+      ],
     },
     {
       title: 'status',
-      output: [{ path: '/test', to: 'https://www.bitballoon.com/test=hello', status: 301 }],
+      output: [
+        {
+          origin: '/test',
+          path: '/test',
+          to: 'https://www.bitballoon.com/test=hello',
+          status: 301,
+        },
+      ],
     },
     {
       title: 'status_force',
-      output: [{ path: '/test', to: 'https://www.bitballoon.com/test=hello', status: 301, force: true }],
+      output: [
+        {
+          origin: '/test',
+          path: '/test',
+          to: 'https://www.bitballoon.com/test=hello',
+          status: 301,
+          force: true,
+        },
+      ],
     },
     {
       title: 'conditions_country',
-      output: [{ path: '/', to: '/china', status: 302, conditions: { Country: 'ch,tw' } }],
+      output: [
+        {
+          origin: '/',
+          path: '/',
+          to: '/china',
+          status: 302,
+          conditions: { Country: 'ch,tw' },
+        },
+      ],
     },
     {
       title: 'conditions_country_language',
-      output: [{ path: '/', to: '/china', status: 302, conditions: { Country: 'il', Language: 'en' } }],
+      output: [
+        {
+          origin: '/',
+          path: '/',
+          to: '/china',
+          status: 302,
+          conditions: { Country: 'il', Language: 'en' },
+        },
+      ],
     },
     {
       title: 'conditions_role',
-      output: [{ path: '/admin/*', to: '/admin/:splat', status: 200, conditions: { Role: 'admin' } }],
+      output: [
+        {
+          origin: '/admin/*',
+          path: '/admin/*',
+          to: '/admin/:splat',
+          status: 200,
+          conditions: { Role: 'admin' },
+        },
+      ],
     },
     {
       title: 'conditions_roles',
-      output: [{ path: '/member/*', to: '/member/:splat', status: 200, conditions: { Role: 'admin,member' } }],
+      output: [
+        {
+          origin: '/member/*',
+          path: '/member/*',
+          to: '/member/:splat',
+          status: 200,
+          conditions: { Role: 'admin,member' },
+        },
+      ],
     },
     {
       title: 'conditions_query',
       output: [
         {
+          origin: '/donate',
           path: '/donate',
           to: '/donate/usa?source=:source&email=:email',
           status: 302,
@@ -125,6 +278,7 @@ each(
       title: 'signed',
       output: [
         {
+          origin: '/api/*',
           path: '/api/*',
           to: 'https://api.example.com/:splat',
           status: 200,
@@ -138,6 +292,7 @@ each(
       title: 'signed_backward_compat',
       output: [
         {
+          origin: '/api/*',
           path: '/api/*',
           to: 'https://api.example.com/:splat',
           status: 200,

--- a/tests/merge.js
+++ b/tests/merge.js
@@ -7,14 +7,66 @@ each(
   [
     { output: [] },
     { fileRedirects: [], configRedirects: [], output: [] },
-    { fileRedirects: [{ from: '/one', to: '/two' }], configRedirects: [], output: [{ from: '/one', to: '/two' }] },
-    { fileRedirects: [], configRedirects: [{ from: '/one', to: '/three' }], output: [{ from: '/one', to: '/three' }] },
     {
-      fileRedirects: [{ from: '/one', to: '/two' }],
-      configRedirects: [{ from: '/one', to: '/three' }],
+      fileRedirects: [
+        {
+          origin: '/one',
+          from: '/one',
+          to: '/two',
+        },
+      ],
+      configRedirects: [],
       output: [
-        { from: '/one', to: '/two' },
-        { from: '/one', to: '/three' },
+        {
+          origin: '/one',
+          from: '/one',
+          to: '/two',
+        },
+      ],
+    },
+    {
+      fileRedirects: [],
+      configRedirects: [
+        {
+          origin: '/one',
+          from: '/one',
+          to: '/three',
+        },
+      ],
+      output: [
+        {
+          origin: '/one',
+          from: '/one',
+          to: '/three',
+        },
+      ],
+    },
+    {
+      fileRedirects: [
+        {
+          origin: '/one',
+          from: '/one',
+          to: '/two',
+        },
+      ],
+      configRedirects: [
+        {
+          origin: '/one',
+          from: '/one',
+          to: '/three',
+        },
+      ],
+      output: [
+        {
+          origin: '/one',
+          from: '/one',
+          to: '/two',
+        },
+        {
+          origin: '/one',
+          from: '/one',
+          to: '/three',
+        },
       ],
     },
   ],

--- a/tests/netlify_config_parser.js
+++ b/tests/netlify_config_parser.js
@@ -22,56 +22,138 @@ each(
     },
     {
       title: 'backward_compat_origin',
-      output: [{ path: '/old-path', to: '/new-path' }],
+      output: [
+        {
+          origin: '/old-path',
+          path: '/old-path',
+          to: '/new-path',
+        },
+      ],
     },
     {
       title: 'backward_compat_destination',
-      output: [{ path: '/old-path', to: '/new-path' }],
+      output: [
+        {
+          origin: '/old-path',
+          path: '/old-path',
+          to: '/new-path',
+        },
+      ],
     },
     {
       title: 'backward_compat_params',
-      output: [{ path: '/old-path', to: '/new-path', query: { path: ':path' } }],
+      output: [
+        {
+          origin: '/old-path',
+          path: '/old-path',
+          to: '/new-path',
+          query: { path: ':path' },
+        },
+      ],
     },
     {
       title: 'backward_compat_parameters',
-      output: [{ path: '/old-path', to: '/new-path', query: { path: ':path' } }],
+      output: [
+        {
+          origin: '/old-path',
+          path: '/old-path',
+          to: '/new-path',
+          query: { path: ':path' },
+        },
+      ],
     },
     {
       title: 'backward_compat_sign',
-      output: [{ path: '/old-path', to: '/new-path', signed: 'api_key' }],
+      output: [
+        {
+          origin: '/old-path',
+          path: '/old-path',
+          to: '/new-path',
+          signed: 'api_key',
+        },
+      ],
     },
     {
       title: 'backward_compat_signing',
-      output: [{ path: '/old-path', to: '/new-path', signed: 'api_key' }],
+      output: [
+        {
+          origin: '/old-path',
+          path: '/old-path',
+          to: '/new-path',
+          signed: 'api_key',
+        },
+      ],
     },
     {
       title: 'from_simple',
-      output: [{ path: '/old-path', to: '/new-path' }],
+      output: [
+        {
+          origin: '/old-path',
+          path: '/old-path',
+          to: '/new-path',
+        },
+      ],
     },
     {
       title: 'from_url',
-      output: [{ scheme: 'http', host: 'www.example.com', path: '/old-path', to: 'http://www.example.com/new-path' }],
+      output: [
+        {
+          origin: 'http://www.example.com/old-path',
+          scheme: 'http',
+          host: 'www.example.com',
+          path: '/old-path',
+          to: 'http://www.example.com/new-path',
+        },
+      ],
     },
     {
       title: 'from_forward',
-      output: [{ path: '/old-path/*', to: '/old-path/:splat', status: 200 }],
+      output: [
+        {
+          origin: '/old-path/*',
+          path: '/old-path/*',
+          to: '/old-path/:splat',
+          status: 200,
+        },
+      ],
     },
     {
       title: 'from_no_slash',
-      output: [{ path: 'old-path', to: 'new-path' }],
+      output: [
+        {
+          origin: 'old-path',
+          path: 'old-path',
+          to: 'new-path',
+        },
+      ],
     },
     {
       title: 'query',
-      output: [{ path: '/old-path', to: '/new-path', query: { path: ':path' } }],
+      output: [
+        {
+          origin: '/old-path',
+          path: '/old-path',
+          to: '/new-path',
+          query: { path: ':path' },
+        },
+      ],
     },
     {
       title: 'signed',
-      output: [{ path: '/old-path', to: '/new-path', signed: 'api_key' }],
+      output: [
+        {
+          origin: '/old-path',
+          path: '/old-path',
+          to: '/new-path',
+          signed: 'api_key',
+        },
+      ],
     },
     {
       title: 'complex',
       output: [
         {
+          origin: '/old-path',
           path: '/old-path',
           to: '/new-path',
           status: 301,
@@ -85,6 +167,7 @@ each(
           },
         },
         {
+          origin: '/search',
           path: '/search',
           to: 'https://api.mysearch.com',
           status: 200,


### PR DESCRIPTION
Fixes #265.

The `origin` field should be returned. 
It combines the `scheme`+`host`+`path` fields, which should still be returned.