### PR TITLE
feat: align `parseAllRedirects()` order with `@netlify/config` order

### DIFF
--- a/src/all.js
+++ b/src/all.js
@@ -10,8 +10,9 @@ const parseAllRedirects = async function ({ redirectsFiles = [], netlifyConfigPa
     getFileRedirects(redirectsFiles),
     getConfigRedirects(netlifyConfigPath),
   ])
-  const redirects = mergeRedirects({ fileRedirects, configRedirects })
-  return normalizeRedirects(redirects)
+  const normalizedFileRedirects = normalizeRedirects(fileRedirects)
+  const normalizedConfigRedirects = normalizeRedirects(configRedirects)
+  return mergeRedirects({ fileRedirects: normalizedFileRedirects, configRedirects: normalizedConfigRedirects })
 }
 
 const getFileRedirects = async function (redirectsFiles) {


### PR DESCRIPTION
Since https://github.com/netlify/build/pull/3242, redirects normalization is happening before redirects merging in `@netlify/config`.
This PR aligns `netlify-redirect-parser` `parseAllRedirects()` (used by `netlify dev`) with this new behavior.