### PR TITLE
feat: add `minimal` option

### DIFF
--- a/src/all.js
+++ b/src/all.js
@@ -5,13 +5,13 @@ const { normalizeRedirects } = require('./normalize')
 
 // Parse all redirects from `netlify.toml` and `_redirects` file, then normalize
 // and validate those.
-const parseAllRedirects = async function ({ redirectsFiles = [], netlifyConfigPath } = {}) {
+const parseAllRedirects = async function ({ redirectsFiles = [], netlifyConfigPath, ...opts } = {}) {
   const [fileRedirects, configRedirects] = await Promise.all([
     getFileRedirects(redirectsFiles),
     getConfigRedirects(netlifyConfigPath),
   ])
-  const normalizedFileRedirects = normalizeRedirects(fileRedirects)
-  const normalizedConfigRedirects = normalizeRedirects(configRedirects)
+  const normalizedFileRedirects = normalizeRedirects(fileRedirects, opts)
+  const normalizedConfigRedirects = normalizeRedirects(configRedirects, opts)
   return mergeRedirects({ fileRedirects: normalizedFileRedirects, configRedirects: normalizedConfigRedirects })
 }
 

--- a/tests/all.js
+++ b/tests/all.js
@@ -5,7 +5,7 @@ const { parseAllRedirects } = require('..')
 
 const { FIXTURES_DIR } = require('./helpers/main')
 
-const parseRedirects = async function ({ fileFixtureNames, configFixtureName }) {
+const parseRedirects = async function ({ fileFixtureNames, configFixtureName, opts }) {
   const redirectsFiles =
     fileFixtureNames === undefined
       ? undefined
@@ -13,7 +13,9 @@ const parseRedirects = async function ({ fileFixtureNames, configFixtureName }) 
   const netlifyConfigPath =
     configFixtureName === undefined ? undefined : `${FIXTURES_DIR}/netlify_config/${configFixtureName}.toml`
   const options =
-    redirectsFiles === undefined && netlifyConfigPath === undefined ? undefined : { redirectsFiles, netlifyConfigPath }
+    redirectsFiles === undefined && netlifyConfigPath === undefined
+      ? opts
+      : { redirectsFiles, netlifyConfigPath, ...opts }
   return await parseAllRedirects(options)
 }
 
@@ -106,10 +108,42 @@ each(
         },
       ],
     },
+    {
+      title: 'minimal',
+      fileFixtureNames: ['from_simple', 'from_absolute_uri'],
+      configFixtureName: 'from_simple',
+      output: [
+        {
+          from: '/home',
+          query: {},
+          to: '/',
+          force: false,
+          conditions: {},
+          headers: {},
+        },
+        {
+          from: 'http://hello.bitballoon.com/*',
+          query: {},
+          to: 'http://www.hello.com/:splat',
+          force: false,
+          conditions: {},
+          headers: {},
+        },
+        {
+          from: '/old-path',
+          query: {},
+          to: '/new-path',
+          force: false,
+          conditions: {},
+          headers: {},
+        },
+      ],
+      opts: { minimal: true },
+    },
   ],
-  ({ title }, { fileFixtureNames, configFixtureName, output }) => {
+  ({ title }, { fileFixtureNames, configFixtureName, output, opts }) => {
     test(`Parses netlify.toml and _redirects | ${title}`, async (t) => {
-      t.deepEqual(await parseRedirects({ fileFixtureNames, configFixtureName }), output)
+      t.deepEqual(await parseRedirects({ fileFixtureNames, configFixtureName, opts }), output)
     })
   },
 )

--- a/tests/fixtures/netlify_config/minimal.toml
+++ b/tests/fixtures/netlify_config/minimal.toml
@@ -1,0 +1,9 @@
+[[redirects]]
+  from = "/here"
+  to = "/there"
+  status = 200
+  force = true
+  headers = {X-From = "Netlify"}
+  query = {path = ":path"}
+  conditions = {Language = ["en"], Country = ["US"], Role = ["admin"]}
+  signed = "API_SIGNATURE_TOKEN"

--- a/tests/helpers/main.js
+++ b/tests/helpers/main.js
@@ -1,12 +1,19 @@
 const FIXTURES_DIR = `${__dirname}/../fixtures`
 
 // Assign default values to redirects
-const normalizeRedirect = function (redirect) {
-  return { ...DEFAULT_REDIRECT, ...redirect }
+const normalizeRedirect = function (redirect, { minimal } = {}) {
+  return {
+    ...(!minimal && ADDED_DEFAULT_REDIRECTS),
+    ...DEFAULT_REDIRECT,
+    ...redirect,
+  }
+}
+
+const ADDED_DEFAULT_REDIRECTS = {
+  proxy: false,
 }
 
 const DEFAULT_REDIRECT = {
-  proxy: false,
   force: false,
   query: {},
   conditions: {},

--- a/tests/netlify_config_parser.js
+++ b/tests/netlify_config_parser.js
@@ -5,9 +5,9 @@ const { parseConfigRedirects, normalizeRedirects } = require('..')
 
 const { FIXTURES_DIR, normalizeRedirect } = require('./helpers/main')
 
-const parseRedirects = async function (fixtureName) {
+const parseRedirects = async function (fixtureName, opts) {
   const redirects = await parseConfigRedirects(`${FIXTURES_DIR}/netlify_config/${fixtureName}.toml`)
-  return normalizeRedirects(redirects)
+  return normalizeRedirects(redirects, opts)
 }
 
 each(
@@ -213,10 +213,38 @@ each(
         },
       ],
     },
+    {
+      title: 'minimal',
+      output: [
+        {
+          from: '/here',
+          to: '/there',
+          status: 200,
+          force: true,
+          signed: 'API_SIGNATURE_TOKEN',
+          headers: {
+            'X-From': 'Netlify',
+          },
+          query: {
+            path: ':path',
+          },
+          conditions: {
+            country: ['US'],
+            language: ['en'],
+            role: ['admin'],
+          },
+        },
+      ],
+      opts: { minimal: true },
+    },
   ],
-  ({ title }, { fixtureName = title, output }) => {
+  ({ title }, { fixtureName = title, output, opts }) => {
     test(`Parses netlify.toml redirects | ${title}`, async (t) => {
-      t.deepEqual(await parseRedirects(fixtureName), output.map(normalizeRedirect))
+      t.deepEqual(
+        await parseRedirects(fixtureName, opts),
+        // eslint-disable-next-line max-nested-callbacks
+        output.map((redirect) => normalizeRedirect(redirect, opts)),
+      )
     })
   },
 )


### PR DESCRIPTION
Parsing redirects adds a few properties that are used by `netlify dev`: `path`, `scheme`, `host`, `proxy`.

However, `@netlify/config` should not receive those properties since it serializes the result back to `netlify.toml` and those properties are invalid in `netlify.toml`.

This PR fixes this by adding a `minimal` boolean option to decide whether to return those properties. It defaults to returning them which is the current behavior, i.e. this is not a breaking change.