### PR TITLE
chore: fix release process

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,7 +12,7 @@ jobs:
         with:
           private-key: ${{ secrets.TOKENS_PRIVATE_KEY }}
           app-id: ${{ secrets.TOKENS_APP_ID }}
-      - uses: GoogleCloudPlatform/release-please-action@v2
+      - uses: GoogleCloudPlatform/release-please-action@d3d5b411d22e25052bb20e73a0ec1b156d67d944
         id: release
         with:
           token: ${{ steps.get-token.outputs.token }}


### PR DESCRIPTION
Temporarily patches the `release-please` action until https://github.com/google-github-actions/release-please-action/issues/337 is fixed.