### PR TITLE
feat: remove duplicates

### DIFF
--- a/src/merge.js
+++ b/src/merge.js
@@ -1,22 +1,28 @@
-const { inspect } = require('util')
+const { inspect, isDeepStrictEqual } = require('util')
 
 // Merge redirects from `_redirects` with the ones from `netlify.toml`.
 // When both are specified, both are used and `_redirects` has priority.
 // Since in both `netlify.toml` and `_redirects`, only the first matching rule
 // is used, it is possible to merge `_redirects` to `netlify.toml` by prepending
 // its rules to `netlify.toml` `redirects` field.
-// This function implements this logic. It is very simple, but it allows
-// changing the merging logic later.
 const mergeRedirects = function ({ fileRedirects = [], configRedirects = [] }) {
   validateArray(fileRedirects)
   validateArray(configRedirects)
-  return [...fileRedirects, ...configRedirects]
+  return [...fileRedirects, ...configRedirects].filter(isUniqueRedirect)
 }
 
 const validateArray = function (redirects) {
   if (!Array.isArray(redirects)) {
     throw new TypeError(`Redirects should be an array: ${inspect(redirects, { colors: false })}`)
   }
+}
+
+// Remove duplicates. This is especially likely considering `fileRedirects`
+// might have been previously merged to `configRedirects`, which happens when
+// `netlifyConfig.redirects` is modified by plugins.
+// The latest duplicate value is the one kept.
+const isUniqueRedirect = function (redirect, index, redirects) {
+  return !redirects.slice(index + 1).some((otherRedirect) => isDeepStrictEqual(redirect, otherRedirect))
 }
 
 module.exports = { mergeRedirects }

--- a/tests/merge.js
+++ b/tests/merge.js
@@ -61,6 +61,42 @@ each(
         },
       ],
     },
+    {
+      fileRedirects: [
+        {
+          from: '/one',
+          to: '/two',
+        },
+        {
+          from: '/one',
+          to: '/four',
+        },
+      ],
+      configRedirects: [
+        {
+          from: '/one',
+          to: '/two',
+        },
+        {
+          from: '/one',
+          to: '/three',
+        },
+      ],
+      output: [
+        {
+          from: '/one',
+          to: '/four',
+        },
+        {
+          from: '/one',
+          to: '/two',
+        },
+        {
+          from: '/one',
+          to: '/three',
+        },
+      ],
+    },
   ],
   ({ title }, { fileRedirects, configRedirects, output }) => {
     test(`Merges _redirects with netlify.toml redirects | ${title}`, (t) => {


### PR DESCRIPTION
See background at https://github.com/netlify/build/pull/3424#discussion_r687150838

This removes duplicate headers with `mergeRedirects()`.