### PR TITLE
feat!: add lenient parsing

### DIFF
--- a/src/line_parser.js
+++ b/src/line_parser.js
@@ -3,6 +3,7 @@ const { promisify } = require('util')
 
 const pathExists = require('path-exists')
 
+const { splitResults } = require('./results')
 const { isUrl } = require('./url')
 
 const pReadFile = promisify(readFile)
@@ -27,11 +28,12 @@ const pReadFile = promisify(readFile)
 // cannot be specified.
 const parseFileRedirects = async function (redirectFile) {
   if (!(await pathExists(redirectFile))) {
-    return []
+    return splitResults([])
   }
 
   const text = await pReadFile(redirectFile, 'utf8')
-  return text.split('\n').map(normalizeLine).filter(hasRedirect).map(parseRedirect)
+  const results = text.split('\n').map(normalizeLine).filter(hasRedirect).map(parseRedirect)
+  return splitResults(results)
 }
 
 const normalizeLine = function (line, index) {
@@ -46,7 +48,7 @@ const parseRedirect = function ({ line, index }) {
   try {
     return parseRedirectLine(line)
   } catch (error) {
-    throw new Error(`Could not parse redirect line ${index + 1}:
+    return new Error(`Could not parse redirect line ${index + 1}:
   ${line}
 ${error.message}`)
   }

--- a/src/merge.js
+++ b/src/merge.js
@@ -1,20 +1,23 @@
 const { inspect, isDeepStrictEqual } = require('util')
 
+const { splitResults } = require('./results')
+
 // Merge redirects from `_redirects` with the ones from `netlify.toml`.
 // When both are specified, both are used and `_redirects` has priority.
 // Since in both `netlify.toml` and `_redirects`, only the first matching rule
 // is used, it is possible to merge `_redirects` to `netlify.toml` by prepending
 // its rules to `netlify.toml` `redirects` field.
 const mergeRedirects = function ({ fileRedirects = [], configRedirects = [] }) {
-  validateArray(fileRedirects)
-  validateArray(configRedirects)
-  return [...fileRedirects, ...configRedirects].filter(isUniqueRedirect)
+  const results = [...validateArray(fileRedirects), ...validateArray(configRedirects)]
+  const { redirects, errors } = splitResults(results)
+  const mergedRedirects = redirects.filter(isUniqueRedirect)
+  return { redirects: mergedRedirects, errors }
 }
 
 const validateArray = function (redirects) {
-  if (!Array.isArray(redirects)) {
-    throw new TypeError(`Redirects should be an array: ${inspect(redirects, { colors: false })}`)
-  }
+  return Array.isArray(redirects)
+    ? redirects
+    : [new TypeError(`Redirects should be an array: ${inspect(redirects, { colors: false })}`)]
 }
 
 // Remove duplicates. This is especially likely considering `fileRedirects`

--- a/src/normalize.js
+++ b/src/normalize.js
@@ -4,6 +4,7 @@ const filterObj = require('filter-obj')
 const isPlainObj = require('is-plain-obj')
 
 const { normalizeConditions } = require('./conditions')
+const { splitResults } = require('./results')
 const { isUrl } = require('./url')
 
 // Validate and normalize an array of `redirects` objects.
@@ -11,21 +12,23 @@ const { isUrl } = require('./url')
 // `netlify.toml` or `_redirects`.
 const normalizeRedirects = function (redirects, opts = {}) {
   if (!Array.isArray(redirects)) {
-    throw new TypeError(`Redirects must be an array not: ${redirects}`)
+    const error = new TypeError(`Redirects must be an array not: ${redirects}`)
+    return splitResults([error])
   }
 
-  return redirects.map((obj, index) => parseRedirect(obj, index, opts))
+  const results = redirects.map((obj, index) => parseRedirect(obj, index, opts))
+  return splitResults(results)
 }
 
 const parseRedirect = function (obj, index, opts) {
   if (!isPlainObj(obj)) {
-    throw new TypeError(`Redirects must be objects not: ${obj}`)
+    return new TypeError(`Redirects must be objects not: ${obj}`)
   }
 
   try {
     return parseRedirectObject(obj, opts)
   } catch (error) {
-    throw new Error(`Could not parse redirect number ${index + 1}:
+    return new Error(`Could not parse redirect number ${index + 1}:
   ${JSON.stringify(obj)}
 ${error.message}`)
   }

--- a/src/results.js
+++ b/src/results.js
@@ -1,0 +1,29 @@
+// If one redirect fails to parse, we still try to return the other ones
+const splitResults = function (results) {
+  const redirects = results.filter((result) => !isError(result))
+  const errors = results.filter(isError)
+  return { redirects, errors }
+}
+
+const isError = function (result) {
+  return result instanceof Error
+}
+
+// Concatenate an array of `{ redirects, erors }`
+const concatResults = function (resultsArrays) {
+  // eslint-disable-next-line unicorn/prefer-spread
+  const redirects = [].concat(...resultsArrays.map(getRedirects))
+  // eslint-disable-next-line unicorn/prefer-spread
+  const errors = [].concat(...resultsArrays.map(getErrors))
+  return { redirects, errors }
+}
+
+const getRedirects = function ({ redirects }) {
+  return redirects
+}
+
+const getErrors = function ({ errors }) {
+  return errors
+}
+
+module.exports = { splitResults, concatResults }

--- a/tests/all.js
+++ b/tests/all.js
@@ -143,7 +143,9 @@ each(
   ],
   ({ title }, { fileFixtureNames, configFixtureName, output, opts }) => {
     test(`Parses netlify.toml and _redirects | ${title}`, async (t) => {
-      t.deepEqual(await parseRedirects({ fileFixtureNames, configFixtureName, opts }), output)
+      const { redirects, errors } = await parseRedirects({ fileFixtureNames, configFixtureName, opts })
+      t.is(errors.length, 0)
+      t.deepEqual(redirects, output)
     })
   },
 )

--- a/tests/merge.js
+++ b/tests/merge.js
@@ -100,7 +100,9 @@ each(
   ],
   ({ title }, { fileRedirects, configRedirects, output }) => {
     test(`Merges _redirects with netlify.toml redirects | ${title}`, (t) => {
-      t.deepEqual(mergeRedirects({ fileRedirects, configRedirects }), output)
+      const { redirects, errors } = mergeRedirects({ fileRedirects, configRedirects })
+      t.is(errors.length, 0)
+      t.deepEqual(redirects, output)
     })
   },
 )
@@ -112,7 +114,10 @@ each(
   ],
   ({ title }, { fileRedirects, configRedirects, errorMessage }) => {
     test(`Validate syntax errors | ${title}`, async (t) => {
-      await t.throws(mergeRedirects.bind(undefined, { fileRedirects, configRedirects }), errorMessage)
+      const { redirects, errors } = await mergeRedirects({ fileRedirects, configRedirects })
+      t.is(redirects.length, 0)
+      // eslint-disable-next-line max-nested-callbacks
+      t.true(errors.some((error) => errorMessage.test(error.message)))
     })
   },
 )


### PR DESCRIPTION
In production, when a specific redirect in either `_redirects` or `netlify.toml` has some syntax error, that redirect is ignored but we still parse the other redirects. However, this library throws instead.

This PR brings the production behavior, so: 
  - The CLI behavior matches it (as part of the world-class local development initiative). 
  - `netlifyConfig.redirects` modifications match it (as part of https://github.com/netlify/build/issues/1193)

It does so by making all methods return an object `{ redirects, errors }` instead of a single array `redirects`. `errors` is an array of error instances.

Sibling PR for headers parsing: https://github.com/netlify/netlify-headers-parser/pull/10