### PR TITLE
feat: add `configRedirects` argument to `parseAllRedirects()`

### DIFF
--- a/src/all.js
+++ b/src/all.js
@@ -4,7 +4,7 @@ const { parseConfigRedirects } = require('./netlify_config_parser')
 const { normalizeRedirects } = require('./normalize')
 const { splitResults, concatResults } = require('./results')
 
-// Parse all redirects from `netlify.toml` and `_redirects` file, then normalize
+// Parse all redirects given programmatically via the `configRedirects` property, `netlify.toml` and `_redirects` files, then normalize
 // and validate those.
 const parseAllRedirects = async function ({
   redirectsFiles = [],

--- a/src/all.js
+++ b/src/all.js
@@ -6,24 +6,34 @@ const { splitResults, concatResults } = require('./results')
 
 // Parse all redirects from `netlify.toml` and `_redirects` file, then normalize
 // and validate those.
-const parseAllRedirects = async function ({ redirectsFiles = [], netlifyConfigPath, ...opts } = {}) {
+const parseAllRedirects = async function ({
+  redirectsFiles = [],
+  netlifyConfigPath,
+  configRedirects = [],
+  ...opts
+} = {}) {
   const [
     { redirects: fileRedirects, errors: fileParseErrors },
-    { redirects: configRedirects, errors: configParseErrors },
+    { redirects: parsedConfigRedirects, errors: configParseErrors },
   ] = await Promise.all([getFileRedirects(redirectsFiles), getConfigRedirects(netlifyConfigPath)])
   const { redirects: normalizedFileRedirects, errors: fileNormalizeErrors } = normalizeRedirects(fileRedirects, opts)
+  const { redirects: normalizedParsedConfigRedirects, errors: parsedConfigNormalizeErrors } = normalizeRedirects(
+    parsedConfigRedirects,
+    opts,
+  )
   const { redirects: normalizedConfigRedirects, errors: configNormalizeErrors } = normalizeRedirects(
     configRedirects,
     opts,
   )
   const { redirects, errors: mergeErrors } = mergeRedirects({
     fileRedirects: normalizedFileRedirects,
-    configRedirects: normalizedConfigRedirects,
+    configRedirects: [...normalizedParsedConfigRedirects, ...normalizedConfigRedirects],
   })
   const errors = [
     ...fileParseErrors,
     ...fileNormalizeErrors,
     ...configParseErrors,
+    ...parsedConfigNormalizeErrors,
     ...configNormalizeErrors,
     ...mergeErrors,
   ]


### PR DESCRIPTION
Part of https://github.com/netlify/build/issues/2890

Like https://github.com/netlify/netlify-headers-parser/pull/11, but for redirects instead of headers.

This adds a `configRedirects` argument to `parseAllRedirects()` to pass headers programmatically instead of specifying a `netlify.toml` path. 

This would be useful for `@netlify/config` since it has already parsed `netlify.toml` and does not need to parse it again. This will allow `@netlify/config` to switch to using `parseAllRedirects()` instead of each method exported by `netlify-redirect-parser`.