### PR TITLE
feat!: simplify exported methods

### DIFF
--- a/src/all.js
+++ b/src/all.js
@@ -6,12 +6,7 @@ const { splitResults, concatResults } = require('./results')
 
 // Parse all redirects given programmatically via the `configRedirects` property, `netlify.toml` and `_redirects` files, then normalize
 // and validate those.
-const parseAllRedirects = async function ({
-  redirectsFiles = [],
-  netlifyConfigPath,
-  configRedirects = [],
-  ...opts
-} = {}) {
+const parseAllRedirects = async function ({ redirectsFiles = [], netlifyConfigPath, configRedirects = [], ...opts }) {
   const [
     { redirects: fileRedirects, errors: fileParseErrors },
     { redirects: parsedConfigRedirects, errors: configParseErrors },

--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,3 @@
 const { parseAllRedirects } = require('./all')
-const { parseFileRedirects } = require('./line_parser')
-const { mergeRedirects } = require('./merge')
-const { parseConfigRedirects } = require('./netlify_config_parser')
-const { normalizeRedirects } = require('./normalize')
 
-module.exports = {
-  parseAllRedirects,
-  parseFileRedirects,
-  mergeRedirects,
-  parseConfigRedirects,
-  normalizeRedirects,
-}
+module.exports = { parseAllRedirects }

--- a/src/merge.js
+++ b/src/merge.js
@@ -1,4 +1,4 @@
-const { inspect, isDeepStrictEqual } = require('util')
+const { isDeepStrictEqual } = require('util')
 
 const { splitResults } = require('./results')
 
@@ -7,17 +7,11 @@ const { splitResults } = require('./results')
 // Since in both `netlify.toml` and `_redirects`, only the first matching rule
 // is used, it is possible to merge `_redirects` to `netlify.toml` by prepending
 // its rules to `netlify.toml` `redirects` field.
-const mergeRedirects = function ({ fileRedirects = [], configRedirects = [] }) {
-  const results = [...validateArray(fileRedirects), ...validateArray(configRedirects)]
+const mergeRedirects = function ({ fileRedirects, configRedirects }) {
+  const results = [...fileRedirects, ...configRedirects]
   const { redirects, errors } = splitResults(results)
   const mergedRedirects = redirects.filter(isUniqueRedirect)
   return { redirects: mergedRedirects, errors }
-}
-
-const validateArray = function (redirects) {
-  return Array.isArray(redirects)
-    ? redirects
-    : [new TypeError(`Redirects should be an array: ${inspect(redirects, { colors: false })}`)]
 }
 
 // Remove duplicates. This is especially likely considering `fileRedirects`

--- a/src/normalize.js
+++ b/src/normalize.js
@@ -10,7 +10,7 @@ const { isUrl } = require('./url')
 // Validate and normalize an array of `redirects` objects.
 // This step is performed after `redirects` have been parsed from either
 // `netlify.toml` or `_redirects`.
-const normalizeRedirects = function (redirects, opts = {}) {
+const normalizeRedirects = function (redirects, opts) {
   if (!Array.isArray(redirects)) {
     const error = new TypeError(`Redirects must be an array not: ${redirects}`)
     return splitResults([error])

--- a/tests/all.js
+++ b/tests/all.js
@@ -12,17 +12,7 @@ const parseRedirects = async function ({ fileFixtureNames, configFixtureName, co
       : fileFixtureNames.map((fileFixtureName) => `${FIXTURES_DIR}/redirects_file/${fileFixtureName}`)
   const netlifyConfigPath =
     configFixtureName === undefined ? undefined : `${FIXTURES_DIR}/netlify_config/${configFixtureName}.toml`
-  const options = getOptions({ redirectsFiles, netlifyConfigPath, configRedirects, opts })
-  return await parseAllRedirects(options)
-}
-
-const getOptions = function ({ redirectsFiles, netlifyConfigPath, configRedirects, opts }) {
-  return redirectsFiles === undefined &&
-    netlifyConfigPath === undefined &&
-    configRedirects === undefined &&
-    opts === undefined
-    ? undefined
-    : { redirectsFiles, netlifyConfigPath, configRedirects, ...opts }
+  return await parseAllRedirects({ redirectsFiles, netlifyConfigPath, configRedirects, ...opts })
 }
 
 each(

--- a/tests/line_parser.js
+++ b/tests/line_parser.js
@@ -1,13 +1,14 @@
 const test = require('ava')
 const { each } = require('test-each')
 
-const { parseFileRedirects, normalizeRedirects } = require('..')
+const { parseFileRedirects } = require('../src/line_parser')
+const { normalizeRedirects } = require('../src/normalize')
 
 const { FIXTURES_DIR, normalizeRedirect } = require('./helpers/main')
 
 const parseRedirects = async function (fixtureName) {
   const { redirects, errors: parseErrors } = await parseFileRedirects(`${FIXTURES_DIR}/redirects_file/${fixtureName}`)
-  const { redirects: normalizedRedirects, errors: normalizeErrors } = normalizeRedirects(redirects)
+  const { redirects: normalizedRedirects, errors: normalizeErrors } = normalizeRedirects(redirects, {})
   return { redirects: normalizedRedirects, errors: [...parseErrors, ...normalizeErrors] }
 }
 

--- a/tests/merge.js
+++ b/tests/merge.js
@@ -1,11 +1,10 @@
 const test = require('ava')
 const { each } = require('test-each')
 
-const { mergeRedirects } = require('..')
+const { mergeRedirects } = require('../src/merge')
 
 each(
   [
-    { output: [] },
     { fileRedirects: [], configRedirects: [], output: [] },
     {
       fileRedirects: [
@@ -103,21 +102,6 @@ each(
       const { redirects, errors } = mergeRedirects({ fileRedirects, configRedirects })
       t.is(errors.length, 0)
       t.deepEqual(redirects, output)
-    })
-  },
-)
-
-each(
-  [
-    { fileRedirects: { from: '/one', to: '/three' }, errorMessage: /should be an array/ },
-    { configRedirects: { from: '/one', to: '/three' }, errorMessage: /should be an array/ },
-  ],
-  ({ title }, { fileRedirects, configRedirects, errorMessage }) => {
-    test(`Validate syntax errors | ${title}`, async (t) => {
-      const { redirects, errors } = await mergeRedirects({ fileRedirects, configRedirects })
-      t.is(redirects.length, 0)
-      // eslint-disable-next-line max-nested-callbacks
-      t.true(errors.some((error) => errorMessage.test(error.message)))
     })
   },
 )

--- a/tests/netlify_config_parser.js
+++ b/tests/netlify_config_parser.js
@@ -1,11 +1,12 @@
 const test = require('ava')
 const { each } = require('test-each')
 
-const { parseConfigRedirects, normalizeRedirects } = require('..')
+const { parseConfigRedirects } = require('../src/netlify_config_parser')
+const { normalizeRedirects } = require('../src/normalize')
 
 const { FIXTURES_DIR, normalizeRedirect } = require('./helpers/main')
 
-const parseRedirects = async function (fixtureName, opts) {
+const parseRedirects = async function (fixtureName, opts = {}) {
   const { redirects, errors: parseErrors } = await parseConfigRedirects(
     `${FIXTURES_DIR}/netlify_config/${fixtureName}.toml`,
   )


### PR DESCRIPTION
Now that the CLI and `@netlify/config` only uses the `parseAllRedirects()` method (see https://github.com/netlify/build/pull/3475), we can export only that method. This will simplify maintaining this module and will keep its API smaller.

Sibling PR for headers: https://github.com/netlify/netlify-headers-parser/pull/13