### PR TITLE
chore: add `path-exists` to `renovate.json5`

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -11,6 +11,10 @@
       allowedVersions: '<4',
     },
     {
+      matchPackageNames: ['path-exists'],
+      allowedVersions: '<5',
+    },
+    {
       matchPackageNames: ['test-each'],
       allowedVersions: '<3',
     },


### PR DESCRIPTION
`path-exists@v5` requires ESM and Node 12.