### PR TITLE
fix: handle `_redirects` with wrong file type

### DIFF
--- a/tests/line_parser.js
+++ b/tests/line_parser.js
@@ -423,6 +423,13 @@ each(
 each(
   [
     {
+      title: 'invalid_dir',
+      input: {
+        redirectsFiles: ['invalid_dir'],
+      },
+      errorMessage: /read redirects file/,
+    },
+    {
       title: 'invalid_url',
       input: {
         redirectsFiles: ['invalid_url'],


### PR DESCRIPTION
We should handle the case where `_redirects` is a directory (which is invalid).

Sibling PR for headers: https://github.com/netlify/netlify-headers-parser/pull/26