### PR TITLE
fix: add feature flags to new status normalization logic

### DIFF
--- a/src/all.js
+++ b/src/all.js
@@ -10,20 +10,27 @@ export const parseAllRedirects = async function ({
   redirectsFiles = [],
   netlifyConfigPath,
   configRedirects = [],
-  ...opts
+  minimal = false,
+  featureFlags = {},
 }) {
   const [
     { redirects: fileRedirects, errors: fileParseErrors },
     { redirects: parsedConfigRedirects, errors: configParseErrors },
-  ] = await Promise.all([getFileRedirects(redirectsFiles), getConfigRedirects(netlifyConfigPath)])
-  const { redirects: normalizedFileRedirects, errors: fileNormalizeErrors } = normalizeRedirects(fileRedirects, opts)
+  ] = await Promise.all([getFileRedirects(redirectsFiles, featureFlags), getConfigRedirects(netlifyConfigPath)])
+  const { redirects: normalizedFileRedirects, errors: fileNormalizeErrors } = normalizeRedirects(
+    fileRedirects,
+    minimal,
+    featureFlags,
+  )
   const { redirects: normalizedParsedConfigRedirects, errors: parsedConfigNormalizeErrors } = normalizeRedirects(
     parsedConfigRedirects,
-    opts,
+    minimal,
+    featureFlags,
   )
   const { redirects: normalizedConfigRedirects, errors: configNormalizeErrors } = normalizeRedirects(
     configRedirects,
-    opts,
+    minimal,
+    featureFlags,
   )
   const { redirects, errors: mergeErrors } = mergeRedirects({
     fileRedirects: normalizedFileRedirects,
@@ -40,8 +47,10 @@ export const parseAllRedirects = async function ({
   return { redirects, errors }
 }
 
-const getFileRedirects = async function (redirectsFiles) {
-  const resultsArrays = await Promise.all(redirectsFiles.map(parseFileRedirects))
+const getFileRedirects = async function (redirectsFiles, featureFlags) {
+  const resultsArrays = await Promise.all(
+    redirectsFiles.map((redirectFile) => parseFileRedirects(redirectFile, featureFlags)),
+  )
   return concatResults(resultsArrays)
 }
 

--- a/src/status.js
+++ b/src/status.js
@@ -18,8 +18,5 @@ export const transtypeStatusCode = function (status) {
 
 // Check whether the field is a valid status code
 export const isValidStatusCode = function (status) {
-  return Number.isInteger(status) && status >= MIN_STATUS && status <= MAX_STATUS
+  return Number.isInteger(status)
 }
-
-const MIN_STATUS = 100
-const MAX_STATUS = 599

--- a/tests/helpers/main.js
+++ b/tests/helpers/main.js
@@ -26,6 +26,7 @@ const parseRedirects = async function ({ redirectsFiles, netlifyConfigPath, conf
     ...(netlifyConfigPath && { netlifyConfigPath: addConfigFixtureDir(netlifyConfigPath) }),
     configRedirects,
     minimal,
+    featureFlags: { redirects_parser_normalize_status: true },
   })
 }
 

--- a/tests/netlify_config_parser.js
+++ b/tests/netlify_config_parser.js
@@ -354,20 +354,6 @@ each(
       errorMessage: /Invalid status code/,
     },
     {
-      title: 'invalid_status_negative',
-      input: {
-        netlifyConfigPath: 'invalid_status_negative',
-      },
-      errorMessage: /Invalid status code/,
-    },
-    {
-      title: 'invalid_status_high',
-      input: {
-        netlifyConfigPath: 'invalid_status_high',
-      },
-      errorMessage: /Invalid status code/,
-    },
-    {
       title: 'invalid_status_empty',
       input: {
         netlifyConfigPath: 'invalid_status_empty',


### PR DESCRIPTION
Related to https://github.com/netlify/build/pull/4184

https://github.com/netlify/netlify-redirect-parser/pull/419 added some logic to better validate when users either:
  - Add a `status` field in `netlify.toml` that is invalid, e.g. it is a string instead of being a number
  - Forget that the third parameter of a `_redirect`'s line should be the status

Before that PR, those errors were leading to `status` being parsed as `NaN`, which gave confusing error messages to users.

However, by making validation stricter, that PR come with some potential risk. Therefore, this current PR is adding some feature flags to it so we can progressively enable and monitor it.

Additionally, it removes the new validation logic which was added to forbid statuses below 100 or above 599.

Note: due to implementation details, all those changes only impact redirects for sites which modify redirects via a Build plugin, such as sites using the Next.js build plugin.

---

For us to review and ship your PR efficiently, please perform the following steps:

- [x] Open a [bug/issue](https://github.com/netlify/netlify-redirect-parser/issues/new/choose) before writing your code
      🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re
      fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [x] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [x] Update or add tests (if any source code was changed or added) 🧪
- [x] Update or add documentation (if features were changed or added) 📝
- [x] Make sure the status checks below are successful ✅