### PR TITLE
fix: remove feature flag `redirects_parser_normalize_status`

### DIFF
--- a/src/all.js
+++ b/src/all.js
@@ -11,26 +11,19 @@ export const parseAllRedirects = async function ({
   netlifyConfigPath,
   configRedirects = [],
   minimal = false,
-  featureFlags = {},
 }) {
   const [
     { redirects: fileRedirects, errors: fileParseErrors },
     { redirects: parsedConfigRedirects, errors: configParseErrors },
-  ] = await Promise.all([getFileRedirects(redirectsFiles, featureFlags), getConfigRedirects(netlifyConfigPath)])
-  const { redirects: normalizedFileRedirects, errors: fileNormalizeErrors } = normalizeRedirects(
-    fileRedirects,
-    minimal,
-    featureFlags,
-  )
+  ] = await Promise.all([getFileRedirects(redirectsFiles), getConfigRedirects(netlifyConfigPath)])
+  const { redirects: normalizedFileRedirects, errors: fileNormalizeErrors } = normalizeRedirects(fileRedirects, minimal)
   const { redirects: normalizedParsedConfigRedirects, errors: parsedConfigNormalizeErrors } = normalizeRedirects(
     parsedConfigRedirects,
     minimal,
-    featureFlags,
   )
   const { redirects: normalizedConfigRedirects, errors: configNormalizeErrors } = normalizeRedirects(
     configRedirects,
     minimal,
-    featureFlags,
   )
   const { redirects, errors: mergeErrors } = mergeRedirects({
     fileRedirects: normalizedFileRedirects,
@@ -47,10 +40,8 @@ export const parseAllRedirects = async function ({
   return { redirects, errors }
 }
 
-const getFileRedirects = async function (redirectsFiles, featureFlags) {
-  const resultsArrays = await Promise.all(
-    redirectsFiles.map((redirectFile) => parseFileRedirects(redirectFile, featureFlags)),
-  )
+const getFileRedirects = async function (redirectsFiles) {
+  const resultsArrays = await Promise.all(redirectsFiles.map((redirectFile) => parseFileRedirects(redirectFile)))
   return concatResults(resultsArrays)
 }
 

--- a/src/normalize.js
+++ b/src/normalize.js
@@ -9,23 +9,23 @@ import { isUrl } from './url.js'
 // Validate and normalize an array of `redirects` objects.
 // This step is performed after `redirects` have been parsed from either
 // `netlify.toml` or `_redirects`.
-export const normalizeRedirects = function (redirects, minimal, featureFlags) {
+export const normalizeRedirects = function (redirects, minimal) {
   if (!Array.isArray(redirects)) {
     const error = new TypeError(`Redirects must be an array not: ${redirects}`)
     return splitResults([error])
   }
 
-  const results = redirects.map((obj, index) => parseRedirect(obj, index, minimal, featureFlags))
+  const results = redirects.map((obj, index) => parseRedirect(obj, index, minimal))
   return splitResults(results)
 }
 
-const parseRedirect = function (obj, index, minimal, featureFlags) {
+const parseRedirect = function (obj, index, minimal) {
   if (!isPlainObj(obj)) {
     return new TypeError(`Redirects must be objects not: ${obj}`)
   }
 
   try {
-    return parseRedirectObject(obj, minimal, featureFlags)
+    return parseRedirectObject(obj, minimal)
   } catch (error) {
     return new Error(`Could not parse redirect number ${index + 1}:
   ${JSON.stringify(obj)}
@@ -56,7 +56,6 @@ const parseRedirectObject = function (
     headers = {},
   },
   minimal,
-  featureFlags,
 ) {
   if (from === undefined) {
     throw new Error('Missing "from" field')
@@ -66,7 +65,7 @@ const parseRedirectObject = function (
     throw new Error('"headers" field must be an object')
   }
 
-  const statusA = featureFlags.redirects_parser_normalize_status ? normalizeStatus(status) : status
+  const statusA = normalizeStatus(status)
   const finalTo = addForwardRule(from, statusA, to)
   const { scheme, host, path } = parseFrom(from)
   const proxy = isProxy(statusA, finalTo)

--- a/tests/helpers/main.js
+++ b/tests/helpers/main.js
@@ -26,7 +26,6 @@ const parseRedirects = async function ({ redirectsFiles, netlifyConfigPath, conf
     ...(netlifyConfigPath && { netlifyConfigPath: addConfigFixtureDir(netlifyConfigPath) }),
     configRedirects,
     minimal,
-    featureFlags: { redirects_parser_normalize_status: true },
   })
 }
 


### PR DESCRIPTION
This removes the `redirects_parser_normalize_status` now that it has been rolled out at 100%.

---

For us to review and ship your PR efficiently, please perform the following steps:

- [x] Open a [bug/issue](https://github.com/netlify/netlify-redirect-parser/issues/new/choose) before writing your code
      🧑‍💻. This ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re
      fixing a typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [x] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [x] Update or add tests (if any source code was changed or added) 🧪
- [x] Update or add documentation (if features were changed or added) 📝
- [x] Make sure the status checks below are successful ✅